### PR TITLE
Fixed Lislia Goldtune quest reward

### DIFF
--- a/highkeep/Lislia_Goldtune.lua
+++ b/highkeep/Lislia_Goldtune.lua
@@ -26,7 +26,7 @@ function event_trade(e)
 		e.other:Faction(e.self,262,1); -- Faction: Guards of Qeynos
 		e.other:Faction(e.self,304,-1); -- Faction: Ring of Scale
 		e.other:Faction(e.self,285,-1); -- Faction: Mayong Mistmoore
-		e.other:QuestReward(e.self,0,0,math.random(1,6),0,300,0);
+		e.other:QuestReward(e.self,0,0,math.random(1,6),0,0,300);
 	end
 	item_lib.return_items(e.self, e.other, e.trade)
 end


### PR DESCRIPTION
QuestReward() is missing a 0 arg and was attempting to give itemid 300 and 0 exp.

https://ptb.discord.com/channels/1133452007412334643/1158887102126227616/1163237994942173204