### PR TITLE
Correct Redwine faction reward

### DIFF
--- a/neriakc/Lokar_To-Biath.lua
+++ b/neriakc/Lokar_To-Biath.lua
@@ -48,7 +48,6 @@ function event_trade(e)
 			e.other:Faction(e.self,236, 10);--Dark Bargainers			
 			e.other:Faction(e.self,370, 1);--Dreadguard Inner
 			e.other:Faction(e.self,334, 1);--Dreadguard Outer
-			e.other:Faction(e.self,236, 1);--Dark Bargainers
 			e.other:QuestReward(e.self,0,0,0,0,0,10); --Quarm exp data. Normally: 100
 			Red_Wine = Red_Wine - 1;
 		until Red_Wine == 0;


### PR DESCRIPTION
This quest was updated from takp quests in this commit: https://github.com/SecretsOTheP/quests/commit/c7de1ea258f2ccd0c13c5b66dbe5d982fce3db38

I am assuming the intent was to make it comparable to the source: https://github.com/EQMacEmu/quests/blob/main/neriakc/Lokar_To-Biath.lua#L48-L50

If that was the intent, this line missed getting deleted. This results in 10% extra faction, but more noticeably two messages that the same faction improved on turn in.