### PR TITLE
Prevent Cleric epic deadlock / grief situation

### DIFF
--- a/timorous/Avatar_of_Water.lua
+++ b/timorous/Avatar_of_Water.lua
@@ -9,7 +9,6 @@ function event_trade(e)
 	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 28023})) then --Orb of the triumvirate
 		e.self:Emote("takes the orb from you. The avatar has determined that you are worthy!");
 		e.other:QuestReward(e.self,0,0,0,0,5532,200000); -- Water Sprinkler of Nem Ankh
-		eq.depop();
 	end
 	item_lib.return_items(e.self, e.other, e.trade) -- return unused items
 end


### PR DESCRIPTION
This allows multiple clerics to turn in triumvirate if one of them missed their chance for whatever reason, instead of creating a race for the mob by possibly blocked clerics sniping the next cleric's chance.