### PR TITLE
Support for Repopping Cleric Epic Mobs

### DIFF
--- a/timorous/Avatar_of_Water.lua
+++ b/timorous/Avatar_of_Water.lua
@@ -9,6 +9,7 @@ function event_trade(e)
 	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 28023})) then --Orb of the triumvirate
 		e.self:Emote("takes the orb from you. The avatar has determined that you are worthy!");
 		e.other:QuestReward(e.self,0,0,0,0,5532,200000); -- Water Sprinkler of Nem Ankh
+		eq.depop();
 	end
 	item_lib.return_items(e.self, e.other, e.trade) -- return unused items
 end

--- a/timorous/Omat_Vastsea.lua
+++ b/timorous/Omat_Vastsea.lua
@@ -28,6 +28,14 @@ function event_trade(e)
 		e.self:Say("I see now that Zordak Ragefire and the exiled elder dragon Zordakalicus were the same being. That explains how he resisted our attempts to divine his affairs and past. Each of these orbs I have granted you represents one of the Triumvirate. Jhassad Oceanson awaits on the shore below to perform the ritual that will merge the orbs into a single Orb of the Triumvirate and summon an avatar from the Plane of Water. Present the Orb of the Triumvirate to the Avatar of Water when it arrives and allow your destiny to be unraveled.");
 		e.other:QuestReward(e.self,0,0,0,0,28050,100000); --Orb of Vapor
 		eq.unique_spawn(96074,0,0,-1781,-11959,14.3,1); --Jhassad Oceanson
+	elseif(item_lib.check_turn_in(e.self, e.trade, {item1 = 28050})) then -- Orb of Vapor (to respawn Jhassad Oceanson in case of depop)
+		e.self:Say("Jhassad Oceanson awaits on the shore below to perform the ritual that will merge the orbs into a single Orb of the Triumvirate and summon an avatar from the Plane of Water. Present the Orb of the Triumvirate to the Avatar of Water when it arrives and allow your destiny to be unraveled.");
+		e.other:QuestReward(e.self,0,0,0,0,28050); --Orb of Vapor
+		eq.unique_spawn(96074,0,0,-1781,-11959,14.3,1); --Jhassad Oceanson
+	elseif(item_lib.check_turn_in(e.self, e.trade, {item1 = 28023})) then -- Orb of the Triumvirate (to respawn Avatar of Water in case of depop)	
+		e.self:Say("The Avatar of Water approaches. You must hand him the Orb of the Triumvirate and it will be decided if it is your destiny to wield the Nem Ankh Sprinkler.");
+		e.other:QuestReward(e.self,0,0,0,0,28023); -- Orb of the Triumvirate
+		eq.unique_spawn(96086,21,0,-1886,-11661,1,192); --Avatar of Water
 	end
 	item_lib.return_items(e.self, e.other, e.trade)
 end


### PR DESCRIPTION
In the event a Cleric attempting their epic is killed by spawned Faydedar, the turn in NPCs are killed by spawned Faydedar, or if another Cleric attempts to use the NPC after their own failed attempt (blocking the current quester) - these changes will allow a turn in of interim step items to Omat Vastsea in order to respawn quest NPCs.  Omat will return the Cleric's item and spawn the appropriate NPC for the final epic turn in.  This effectively, prevents Clerics from griefing one another due to botched prior turn ins.