### PR TITLE
Prevent boats in timorous instances from spawning

### DIFF
--- a/timorous/Barrel_Barge.lua
+++ b/timorous/Barrel_Barge.lua
@@ -1,4 +1,8 @@
 function event_spawn(e)
+	if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+		eq.depop();
+    end
+
 	local zone_time = eq.get_zone_time();
 	local hour = zone_time["zone_hour"];
 	local minute = zone_time["zone_minute"];

--- a/timorous/Bloated_Belly.lua
+++ b/timorous/Bloated_Belly.lua
@@ -1,4 +1,8 @@
 function event_spawn(e)
+	if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+		eq.depop();
+    end
+
 	local zone_time = eq.get_zone_time();
 	local hour = zone_time["zone_hour"];
 	local minute = zone_time["zone_minute"];

--- a/timorous/Captains_Skiff.lua
+++ b/timorous/Captains_Skiff.lua
@@ -1,4 +1,11 @@
-function event_signal(e) 		
+function event_spawn(e)
+	if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+		eq.debug("We are in an instance, ignoring event_spawn for " .. e.self:GetName());
+		eq.depop();
+    end
+end
+
+function event_signal(e) 
 	if(e.signal == 1) then 		
  		eq.start(4);
 	end

--- a/timorous/Island_Shuttle.lua
+++ b/timorous/Island_Shuttle.lua
@@ -1,4 +1,11 @@
-function event_signal(e) 		
+function event_spawn(e)
+	if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+		eq.debug("We are in an instance, ignoring event_spawn for " .. e.self:GetName());
+		eq.depop();
+    end
+end
+
+function event_signal(e) 
 	if(e.signal == 1) then 		
  		eq.start(3); 		
  	elseif(e.signal == 2) then 		

--- a/timorous/Maidens_Voyage.lua
+++ b/timorous/Maidens_Voyage.lua
@@ -1,4 +1,9 @@
 function event_spawn(e)
+	if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+		eq.debug("We are in an instance, ignoring event_spawn for " .. e.self:GetName());
+    	eq.depop();
+    end
+
 	local zone_time = eq.get_zone_time();
 	local hour = zone_time["zone_hour"];
 	local minute = zone_time["zone_minute"];

--- a/timorous/Muckskimmer.lua
+++ b/timorous/Muckskimmer.lua
@@ -1,4 +1,9 @@
 function event_spawn(e)
+	if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+		eq.debug("We are in an instance, ignoring event_spawn for " .. e.self:GetName());
+    	eq.depop();
+    end
+
 	local zone_time = eq.get_zone_time();
 	local hour = zone_time["zone_hour"];
 	local minute = zone_time["zone_minute"];

--- a/timorous/Shuttle_I.lua
+++ b/timorous/Shuttle_I.lua
@@ -1,4 +1,9 @@
 function event_spawn(e)
+    if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+        eq.debug("We are in an instance, ignoring event_spawn for " .. e.self:GetName());
+    	eq.depop();
+    end
+
     local zone_time = eq.get_zone_time();
     local hour = zone_time["zone_hour"];
     local minute = zone_time["zone_minute"];

--- a/timorous/Shuttle_II.lua
+++ b/timorous/Shuttle_II.lua
@@ -1,4 +1,9 @@
 function event_spawn(e)
+    if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+        eq.debug("We are in an instance, ignoring event_spawn for " .. e.self:GetName());
+    	eq.depop();
+    end
+
     local zone_time = eq.get_zone_time();
     local hour = zone_time["zone_hour"];
     local minute = zone_time["zone_minute"];

--- a/timorous/Shuttle_III.lua
+++ b/timorous/Shuttle_III.lua
@@ -1,4 +1,9 @@
 function event_spawn(e)
+    if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+        eq.debug("We are in an instance, ignoring event_spawn for " .. e.self:GetName());
+    	eq.depop();
+    end
+
     local zone_time = eq.get_zone_time();
     local hour = zone_time["zone_hour"];
     local minute = zone_time["zone_minute"];

--- a/timorous/Shuttle_IV.lua
+++ b/timorous/Shuttle_IV.lua
@@ -1,4 +1,9 @@
 function event_spawn(e)
+    if (eq.get_zone_guild_id() ~= 0xFFFFFFFF) then
+        eq.debug("We are in an instance, ignoring event_spawn for " .. e.self:GetName());
+    	eq.depop();
+    end
+
     local zone_time = eq.get_zone_time();
     local hour = zone_time["zone_hour"];
     local minute = zone_time["zone_minute"];


### PR DESCRIPTION
Boats in instanced timorous are signaling and modifying global states simultaneously with the non-instanced timorous zone.  This is causing strange behaviors as multiple sets of boats are active at the same time attempting to coordinate with each other.  This patch will prevent instanced boats from spawning and interacting with the world.