### PR TITLE
Changed expansion check in fearplane/fear_instanced to new TAKP content system

### DIFF
--- a/fear_instanced/Dread.lua
+++ b/fear_instanced/Dread.lua
@@ -7,8 +7,9 @@ function event_signal(e)
 end
 
 function event_death_complete(e)
-	local expansion_flag = eq.get_current_expansion();
-	if(expansion_flag >= 2.0 and math.random(100) > 24) then
-		eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+	if(eq.is_the_ruins_of_kunark_enabled()) then
+		if(math.random(100) > 24) then
+			eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+		end
 	end
 end

--- a/fear_instanced/Fright.lua
+++ b/fear_instanced/Fright.lua
@@ -7,9 +7,9 @@ function event_signal(e)
 end
 
 function event_death_complete(e)
-
-	local expansion_flag = eq.get_current_expansion();
-	if(expansion_flag >= 2.0 and math.random(100) > 24) then
-		eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+	if(eq.is_the_ruins_of_kunark_enabled()) then
+		if(math.random(100) > 24) then
+			eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+		end
 	end
 end

--- a/fear_instanced/Terror.lua
+++ b/fear_instanced/Terror.lua
@@ -7,8 +7,9 @@ function event_signal(e)
 end
 
 function event_death_complete(e)
-	local expansion_flag = eq.get_current_expansion();
-	if(expansion_flag >= 2.0 and math.random(100) > 24) then
-		eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+	if(eq.is_the_ruins_of_kunark_enabled()) then
+		if(math.random(100) > 24) then
+			eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+		end
 	end
 end

--- a/fearplane/Dread.lua
+++ b/fearplane/Dread.lua
@@ -7,8 +7,9 @@ function event_signal(e)
 end
 
 function event_death_complete(e)
-	local expansion_flag = eq.get_current_expansion();
-	if(expansion_flag >= 2.0 and math.random(100) > 24) then
-		eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+	if(eq.is_the_ruins_of_kunark_enabled()) then
+		if(math.random(100) > 24) then
+			eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+		end
 	end
 end

--- a/fearplane/Fright.lua
+++ b/fearplane/Fright.lua
@@ -7,9 +7,9 @@ function event_signal(e)
 end
 
 function event_death_complete(e)
-
-	local expansion_flag = eq.get_current_expansion();
-	if(expansion_flag >= 2.0 and math.random(100) > 24) then
-		eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+	if(eq.is_the_ruins_of_kunark_enabled()) then
+		if(math.random(100) > 24) then
+			eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+		end
 	end
 end

--- a/fearplane/Terror.lua
+++ b/fearplane/Terror.lua
@@ -7,8 +7,9 @@ function event_signal(e)
 end
 
 function event_death_complete(e)
-	local expansion_flag = eq.get_current_expansion();
-	if(expansion_flag >= 2.0 and math.random(100) > 24) then
-		eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+	if(eq.is_the_ruins_of_kunark_enabled()) then
+		if(math.random(100) > 24) then
+			eq.spawn2(72105,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
+		end
 	end
 end


### PR DESCRIPTION
During the recent TAKP peq_expansion update, expansion values changed from Classic = 1 to Classic = 0 and subsequently all expansions values were decremented by 1. Several areas rely on these expansion values by integer and these fearplane and fear_instanced scripts were causalities of the change.  Modified scripts to match TAKP content system updates.