### PR TITLE
Timorous Deep - an_Iksar_master dialogue fix

### DIFF
--- a/timorous/an_Iksar_master.lua
+++ b/timorous/an_Iksar_master.lua
@@ -4,15 +4,11 @@ function event_say(e)
 		if(e.message:findi("student")) then
 			e.self:Emote("hands you what appears to be the base of a key. 'This was delivered to me by a dying student. He collapsed just after handing it to me. He was accompanying a student of mine named Veltar. They were questing for the legendary Whistling Fists. The key is made of a metal I have never felt or heard of. Find him.'");
 			e.other:SummonCursorItem(17040); -- Item: Part of a Large Key
-		end
-	elseif(eq.is_the_ruins_of_kunark_enabled()) then
-		if(e.message:findi("test of patience") or e.message:findi("trial of patience")) then
+		elseif(e.message:findi("test of patience") or e.message:findi("trial of patience")) then
 			e.self:Say("So your time has finally come to be tested for the final rung. To show your patience you shall spar with me. When you have gained the insight and strategy to strike you will know when. Strike me too soon and you will perish, too late and I will be gone. Come at me when the time is right. Let us begin.");
 			eq.unique_spawn(96318,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
 			eq.depop_with_timer();
-		end
-	else
-		if(e.message:findi("hail")) then
+		elseif(e.message:findi("hail")) then
 			e.self:Emote("is humming and chanting softly. He seems oblivious to your presence.");
 		elseif(e.message:findi("master rinmark")) then
 			e.self:Emote("squints one eye open, then returns to his meditation.");


### PR DESCRIPTION
The gating logic was causing the `test/trial of patience` dialog to not be able to trigger.