### PR TITLE
Adjust required lvl for self-found bar enchant

### DIFF
--- a/lua_modules/self_found_enchant_bars.lua
+++ b/lua_modules/self_found_enchant_bars.lua
@@ -54,7 +54,7 @@ function enchant_bars._get_bar_data()
             -- gold
             bar_name = "gold",
             component_name = "Gold Bar",
-            required_level = 24,
+            required_level = 20,
             bar_id = 16502,
             reward_id = 16506,
             plat_cost = 25,
@@ -63,7 +63,7 @@ function enchant_bars._get_bar_data()
             -- platinum
             bar_name = "platinum",
             component_name = "Platinum Bar",
-            required_level = 34,
+            required_level = 24,
             bar_id = 16503,
             reward_id = 16507,
             plat_cost = 50,


### PR DESCRIPTION
Enchanted gold and platinum are used in a number of mid-20s quests, notably cleric and shadow knight sol ro quests. Adjusted gold/plat bar levels in accordance.