### PR TITLE
Crude turnin support for stacked items at the library level

### DIFF
--- a/lua_modules/items.lua
+++ b/lua_modules/items.lua
@@ -496,6 +496,11 @@ function items.count_handed_item(npc, trade, items, min_count)
 		if(inst ~= nil and inst.valid) then
 			if(inst:GetID() > 0 and (itemid1 == inst:GetID() or itemid2 == inst:GetID() or itemid3 == inst:GetID() or itemid4 == inst:GetID() or 
 			itemid5 == inst:GetID() or itemid6 == inst:GetID() or itemid7 == inst:GetID() or itemid8 == inst:GetID())) then
+                                while(inst:IsStackable() and inst:GetCharges() > 1) do
+                                        count = count + 1
+                                        handed_count = handed_count + 1;
+                                        inst:SetCharges(inst:GetCharges() - 1)
+                                end
 				count = count + 1;
 				handed_count = handed_count + 1;
 				if(min_count > 1) then


### PR DESCRIPTION
Crude quest turn in support for stacked items like goblin skins, but at the library level


Note: This has not been tested in terms of will it give back stacks that aren't right, etc. This is basically a small QoL change with sharp edges if its not the right kind of turn in, but honestly its fine because it would eat the items previously.