### PR TITLE
Fix NG+ typo and removing unused respec script

### DIFF
--- a/global/Priest_of_Discord.lua
+++ b/global/Priest_of_Discord.lua
@@ -23,19 +23,6 @@ function event_say(e)
 		e.self:Say("Bring me a Vial of Swirling Smoke and this token, and a Queen you shall be.");
 		e.other:SummonCursorItem(13993); -- 'Queen'
 		return;
-
-	elseif(false and e.message:findi("attribute points")) then
-		local stats = eq.ParseAttributes(e.message);
-		local total = stats.STR + stats.STA + stats.AGI + stats.DEX + stats.WIS + stats.INT + stats.CHA;
-		if (total == 0 or not e.message:findi("change")) then
-			e.self:Say("To retrain your natural abilities, you must declare you goal to [change attributes points].");
-			e.other:Message(15, "Your [attribute points] must be written out in this format: 10 int 5 wis 15 cha.");
-			e.other:Message(15, "Attributes can only be changed every 7 days.");
-		elseif (e.other:PermaStats(stats.STR, stats.STA, stats.AGI, stats.DEX, stats.WIS, stats.INT, stats.CHA, false)) then
-			e.other:Save();
-			e.self:Say("Your body and mind will start to adjust. Now go. You must rest or leave to complete this process.");
-		end
-		return;
 		
 	elseif(e.message:findi("newgame plus")) then
 		if (e.other:GetLevel() > 10) then
@@ -48,7 +35,7 @@ function event_say(e)
 			if (gender == -1 or race == -1 or deity == -1 or city == -1 or total == 0) then
 				e.self:Say("Choose your new identity and begin a new adventure. Speak to me again and declare your [newgame plus] [gender], [race], [deity], [home city], and [attribute points].");
 				e.other:Message(15, "Your [attribute points] must be written out in a format such as: 10 int 5 wis 15 cha");
-				e.other:Message(15, "You level will be reset back to level 10, along with your faction and location. Your spells, AAs, and skill ranks will remain intact.");
+				e.other:Message(15, "Your level will be reset back to level 10, along with your faction and location. Your spells, AAs, and skill ranks will remain intact.");
 				return;
 			end
 			if (e.other:PermaRace(race, deity, city, stats.STR, stats.STA, stats.AGI, stats.DEX, stats.WIS, stats.INT, stats.CHA)) then


### PR DESCRIPTION
Removing the respec dialogic, rather than having it disabled. So it doesn't confuse people on PQDI.