### PR TITLE
Require level 1 for NG+Barb Pally

### DIFF
--- a/lua_modules/newgameplus.lua
+++ b/lua_modules/newgameplus.lua
@@ -19,7 +19,7 @@ function ng.Definitions(e)
 	-- Barbarian Paladin race-change. Available to non-barbarian paladins.
 	configs[2] = {
 		name = "(Race Change) Barbarian Paladin",
-		minLevel = 30,
+		minLevel = 1,
 		isRaceChange = true,
 		curClass = "Paladin",
 		mustRaceChange = "Barbarian",  -- Must change to Barbarian, and must not already be Barbarian
@@ -30,7 +30,7 @@ function ng.Definitions(e)
 	-- Barbarian Paladin class-change. Available to non-paladin barbarians.
 	configs[3] = {
 		name = "(Class Change) Barbarian Paladin",
-		minLevel = 30,
+		minLevel = 1,
 		isClassChange = true,
 		curRace = "Barbarian",
 		mustClassChange = "Paladin", -- Must change to Paladin, and must not already be Paladin


### PR DESCRIPTION
If you didn't already change locally, this is all that's needed for level 1 NG+Barb Pally, if that's the plan still.