### PR TITLE
Fix: Several SF quests (enchanting, rebreathers, etc) to detect SF+

### DIFF
--- a/cabeast/Belner_Snuckery.lua
+++ b/cabeast/Belner_Snuckery.lua
@@ -2,7 +2,7 @@ function event_say(e)
 	local enchant_bars_lib = require("self_found_enchant_bars");
 	-- enchant_bars_lib.check_bars_quest_dialogue(e.self, e.other, e.message);
 
-	local is_self_found = e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1;
+	local is_self_found = e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1;
     if(is_self_found) then
 
         local bar_data_list = enchant_bars_lib._get_bar_data();

--- a/commons/Noresa_Sparkle.lua
+++ b/commons/Noresa_Sparkle.lua
@@ -4,7 +4,7 @@ function event_say(e)
 	elseif(e.message:findi("Kizdean")) then
 		e.self:Say("Sshhh..Please..save me. Get..rid..of..him.");
 	end
-	if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+	if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 		if(e.message:findi("Hail")) then
 			e.self:Say("You might also call to Glyssa Sonshaw in Freeport if you seek enchantments of silver and gold.");
 		end

--- a/erudnint/Sothure_Gemcutter.lua
+++ b/erudnint/Sothure_Gemcutter.lua
@@ -1,5 +1,5 @@
 function event_say(e)
-	if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+	if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 		if(e.message:findi("Hail")) then
 			e.self:Say("Nikina Sparlek awaits your arrival inside the Tower of the Craft Keepers. A master enchanter, Nikina has the power to weave spells that bind the essence of magic to your silver and gold. Go forth and ask her about enchantments.");
 		end

--- a/felwithea/Merchant_Silspin.lua
+++ b/felwithea/Merchant_Silspin.lua
@@ -1,5 +1,5 @@
 function event_say(e)
-	if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+	if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 		if(e.message:findi("Hail")) then
 			e.self:Say("Kinool Goldsinger awaits your arrival in the mystical confines of the Keepers of the Art in Southern Felwithe. A master enchanter, Kinool has the power to weave spells that bind the essence of magic to your silver and gold. Go forth and ask him about enchantments.");
 		end

--- a/freportn/Amber.lua
+++ b/freportn/Amber.lua
@@ -1,5 +1,5 @@
 function event_say(e)
-	if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+	if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 		if(e.message:findi("Hail")) then
 			e.self:Say("Glyssa Sonshaw awaits your arrival outside the Academy of Arcane Science. A master enchanter, Glyssa has the power to weave spells that bind the essence of magic to your silver and gold. Go forth and ask her about enchantments.");
 		end

--- a/gfaydark/Merchant_Kweili.lua
+++ b/gfaydark/Merchant_Kweili.lua
@@ -1,5 +1,5 @@
 function event_say(e)
-	if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+	if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 		if(e.message:findi("Hail")) then
 			e.self:Say("Kinool Goldsinger awaits your arrival in the mystical confines of the Keepers of the Art in Felwithe. A master enchanter, Kinool has the power to weave spells that bind the essence of magic to your silver and gold. Go forth and ask him about enchantments.");
 		end

--- a/kaladimb/Aanina_Rockfinder.lua
+++ b/kaladimb/Aanina_Rockfinder.lua
@@ -1,5 +1,5 @@
 function event_say(e)
-	if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+	if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 		if(e.message:findi("Hail")) then
 			e.self:Say("Kinool Goldsinger awaits your arrival in the mystical confines of the Keepers of the Art in Felwithe. A master enchanter, Kinool has the power to weave spells that bind the essence of magic to your silver and gold. Go forth and ask him about enchantments.");
 		end

--- a/lua_modules/self_found_enchant_bars.lua
+++ b/lua_modules/self_found_enchant_bars.lua
@@ -176,7 +176,7 @@ end
 
 function enchant_bars.check_bars_quest_dialogue(self, other, message)
 
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
     if(is_self_found) then
 
         local bar_data_list = enchant_bars._get_bar_data();
@@ -218,7 +218,7 @@ end
 
 function enchant_bars.check_for_bars_to_enchant(item_lib, self, other, trade, require_cast)
 
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
 
     local bar_data_list = enchant_bars._get_bar_data();
 

--- a/lua_modules/self_found_imbue_gems.lua
+++ b/lua_modules/self_found_imbue_gems.lua
@@ -1,7 +1,7 @@
 local module = {}
 
 function module.hail_dialog(self, other, message, subject)
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
     if not is_self_found then
         return false;
     end
@@ -20,7 +20,7 @@ function module.hail_dialog(self, other, message, subject)
 end
 
 function module.check_dialog(self, other, message, subject)
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
     if not is_self_found then
         return false;
     end
@@ -53,7 +53,7 @@ function module.check_dialog(self, other, message, subject)
 end
 
 function module.check_turn_in(item_lib, self, other, trade, subject)
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
     if not is_self_found then
         return false;
     end

--- a/lua_modules/self_found_mind_melt.lua
+++ b/lua_modules/self_found_mind_melt.lua
@@ -5,7 +5,7 @@ function module.check_dialog(self, other, message)
         return false;
     end
 
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
     if not is_self_found then
         return false;
     end
@@ -30,7 +30,7 @@ function module.check_turn_in(item_lib, self, other, trade)
         return false;
     end
 
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
     if not is_self_found then
         return false;
     end

--- a/lua_modules/self_found_rebreathers.lua
+++ b/lua_modules/self_found_rebreathers.lua
@@ -1,7 +1,7 @@
 local module = {}
 
 function module.check_dialog(self, other, message)
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
     local is_warrior = other:GetClass() == 1;
     if(is_self_found) then
         if(message:findi("rebreather")) then
@@ -19,7 +19,7 @@ function module.check_dialog(self, other, message)
 end
 
 function module.check_turn_in(item_lib, self, other, trade)
-    local is_self_found = other:IsSelfFound() == 1 or other:IsSoloOnly() == 1;
+    local is_self_found = other:IsSelfFound() >= 1 or other:IsSoloOnly() == 1;
     local is_warrior = other:GetClass() == 1;
     if(is_self_found) then
         if (is_warrior and other:GetLevel() >= 46) then

--- a/neriaka/Canarie.lua
+++ b/neriaka/Canarie.lua
@@ -1,5 +1,5 @@
 function event_say(e)
-	if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+	if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 		if(e.message:findi("Hail")) then
 			e.self:Say("Drizm J`Axx awaits your arrival in Neriak Commons. A master enchanter, Drizm has the power to weave spells that bind the essence of magic to your silver and gold. Go forth and ask him about enchantments.");
 		end

--- a/neriakb/Zartox_Ru-Soe.lua
+++ b/neriakb/Zartox_Ru-Soe.lua
@@ -1,5 +1,5 @@
 function event_say(e)
-	if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+	if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 		if(e.message:findi("Hail")) then
 			e.self:Say("Drizm J`Axx awaits your arrival. A master enchanter, Drizm has the power to weave spells that bind the essence of magic to your silver and gold. Go forth and ask him about enchantments.");
 		end

--- a/qeynos2/Ziska_Ironforge.lua
+++ b/qeynos2/Ziska_Ironforge.lua
@@ -1,7 +1,7 @@
 function event_say(e)
 	if(e.message:findi("hail")) then
 		e.self:Say("Welcome to our home of the finest jewelers in all of Norrath.");
-		if(e.other:IsSelfFound() == 1 or e.other:IsSoloOnly() == 1) then
+		if(e.other:IsSelfFound() >= 1 or e.other:IsSoloOnly() == 1) then
 			e.self:Say("Esdia Moeba awaits your arrival in South Qeynos. A master enchanter, she has the power to weave spells that bind the essence of magic to your silver and gold. Go forth and ask her about enchantments.");
 		end
 	elseif(e.message:findi("Tayla")) then


### PR DESCRIPTION
- Allows SF+ players to also access SF quests. (Bar/Vial enchanting, etc)
- Enables multi-turn-in support for SF enchanting. (Note: I tested this pretty extensively and it's working)