### PR TITLE
Shawl 8 - Disable MQ, fix sniping, allow multi-turn-in

### DIFF
--- a/iceclad/Avatar_of_Below.lua
+++ b/iceclad/Avatar_of_Below.lua
@@ -1,13 +1,18 @@
 function event_trade(e)
 	local item_lib = require("items");
 	
-	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 1199}, 0) or item_lib.check_turn_in(e.self, e.trade, {item1 = 8895}, 0)) then -- Runed Coldain Prayer Shawl (mark A or mark B)
+	if(item_lib.check_turn_in_nomq(e.self, e.trade, {item1 = 1199, item2 = 8898}, 0) or item_lib.check_turn_in_nomq(e.self, e.trade, {item1 = 8895, item2 = 8898}, 0)) then -- Runed Coldain Prayer Shawl (mark A or mark B) + Approved Issue Kit
 		e.self:Emote("holds the shawl up close to one eye to look at the rune sewn into it. He smiles to himself and then drops it to the ground and places one hand on it. A bright blue glow starts to emanate in the snow, then there is a sudden flash! The Avatar has dissipated. All that is left behind is the Shawl lying in the snow, shimmering with a new power. " .. e.other:GetCleanName() .. " slowly bends down to pick it up, and is infused with a blessing from Brell.");
 		e.other:QuestReward(e.self,0,0,0,0,1200,100000); -- Blessed Coldain Prayer Shawl
-		eq.get_entity_list():GetMobByNpcTypeID(110019):Say("I must go tell the Dain of these events immediately!");
-		eq.get_entity_list():GetMobByNpcTypeID(110069):Say("Yar ya do that ya crazy Coldain.");
-		eq.depop(110019)
-		eq.depop();
+		if(eq.get_entity_list():IsMobSpawnedByNpcTypeID(110019)) then
+			eq.get_entity_list():GetMobByNpcTypeID(110019):Say("I must go tell the Dain of these events immediately!");
+			eq.depop(110019);
+			if(eq.get_entity_list():IsMobSpawnedByNpcTypeID(110069)) then
+				eq.get_entity_list():GetMobByNpcTypeID(110069):Say("Yar ya do that ya crazy Coldain.");
+			end
+		end
+	else
+		e.other:Message(0, "The Avatar of Below tells you, 'I require your Runed Coldain Prayer Shawl and Approved Issue Kit.'");
 	end
-	item_lib.return_items(e.self, e.other, e.trade)
+	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/iceclad/General_Bragmur.lua
+++ b/iceclad/General_Bragmur.lua
@@ -8,6 +8,7 @@ function event_trade(e)
 	local item_lib = require("items");
 	
 	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 8898}, 0)) then
+		e.other:QuestReward(e.self,0,0,0,0,8898,0); -- return the Approved Issue Kit (hand in at end to Avatar with Shawl)
 		e.self:Emote("begins to put the armor on, 'Finally the Dain has gotten word of my arrival here.  I await his final orders before proceeding.'");
 		eq.spawn2(110017,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());
 		eq.depop_with_timer();

--- a/thurgadinb/#Dain_Frostreaver_IV.lua
+++ b/thurgadinb/#Dain_Frostreaver_IV.lua
@@ -29,9 +29,9 @@ end
 function event_trade(e)
 	local item_lib = require("items");
 	
-	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 8886}, 0)) then -- Coldain Standard Issue Kit
+	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 8886}, 0) or item_lib.check_turn_in(e.self, e.trade, {item1 = 8898}, 0)) then -- Coldain Standard Issue Kit, Approved Issue Kit
 		e.self:Say("Excellent work " .. e.other:GetCleanName() .. ". If I didn't know I would assume this was made by our most skilled artisans.  You must hurry, General Bragmur has formed camp in Iceclad. Take the kit to the General, he had to drudge forward without any armor. His [mission] must be a success if we hope to successfully defend Thurgadin against the Giants.");
-		e.other:QuestReward(e.self,{items = {8898,8897}}); -- Expedition Orders, Approved Issue Kit
+		e.other:QuestReward(e.self,{items = {8898,8897}}); -- Approved Issue Kit, Expedition Orders
 	elseif(item_lib.check_turn_in(e.self, e.trade, {item1 = 1199}, 0) or item_lib.check_turn_in(e.self, e.trade, {item1 = 8895}, 0)) then
 		e.self:Say("Ah " .. e.other:GetCleanName() .. ". I was hoping to see you. We require your skilled hand. The Armory is overtaxed preparing armor for the war we are preparing to wage on the Kromzek. We need you to help by creating some Field Plate for a mission that is near to execution. Go see Loremaster Solstrin in the Hall of Ancestors, give him these orders. He holds the lore recorded on how to make the field plate. Return to me when you have completed a Standard Issue Kit.");
 		e.other:QuestReward(e.self,{items = {8895,8896}}); -- Royal Coldain Orders, Runed Coldain Prayer Shawl (mark 2)


### PR DESCRIPTION
- Shawl 8 can no longer be skipped/multi-quested by having someone else spawn the event with their crafted materials.
- Shawl 8 final turn-in changed to prevent a stranger sniping the reward. Multiple participants to complete it upon success:
  - Avatar of Below will no longer despawn instantly after the first player to turn in Shawl 7.
  - Avatar of Below now requires the Shawl 7 + Approved Issue Kit (instead of just the Shawl) to complete the final turn in, as proof of doing all the crafting for Shawl 8.
  - General Bragmur now returns the Approved Issue Kit when you start the escort (So you will have it to hand it to Avatar of Below upon success).

These tweaks were designed to prevent bad behavior caused by how someone could 'skip' the whole Shawl 8 if they just waited for the guy to spawn and sniped the turn in (or paid someone to allow them to).

It is also aimed to reward players that work together to assist with the final combat portion of the quest, because it is a farily slow escort it would be nice to encourage players to participate and achieve this together. Otherwise players will quickly tire of doing this escort for each other.

This also prevents people from just buying an MQ of the Shawl 8, skipping all the crafting steps.

It seems like a fair tradeoff. The spirit of the shawl is the crafting grind. The minor combat/escort portion is a challenge, just not one that needs to be done for the 100th time as players start to complete their shawls. The removal of MQs and skips seems like a fair way to balance it in exchange for multiple completions.

(The General is 4 hour respawn, so people would get really bottlenecked on a fairly trivial portion of this, all things considered)