### PR TITLE
[Ring9] Peffin's guard will now depop after Peffin's death

### DIFF
--- a/eastwastes/#Peffin_Ambersnow.lua
+++ b/eastwastes/#Peffin_Ambersnow.lua
@@ -18,3 +18,8 @@ function event_timer(e)
 	eq.depop_all(116040);
 	eq.depop();
 end
+
+function event_death_complete(e)
+	eq.depop_all(116040);
+	eq.depop_all(116182);
+end

--- a/eastwastes/Peffin_Ambersnow.lua
+++ b/eastwastes/Peffin_Ambersnow.lua
@@ -20,6 +20,8 @@ function event_trade(e)
 end
 
 function PeffinCampFire(e)
+	eq.depop_all(116040);
+	eq.depop_all(116182);
 	eq.unique_spawn(116038,0,0,3413,-1742,143,194); -- NPC: #Peffin_Ambersnow
 	eq.spawn2(116040,0,0,3411,-1768,155,194); -- NPC: #Kromrif_Elite
 	eq.spawn2(116040,0,0,3382,-1754,155,194); -- NPC: #Kromrif_Elite


### PR DESCRIPTION
Fixed issues that would cause Peffin's guards to infinitely grow in number over time.
- #Peffin's guards will now depop after #Peffin's death.
- #Peffin's guards (from previous #Peffins) will now depop when #Peffin spawns with a fresh set of Guards, if for any reason they are still alive. Prevents duplicate guards up at the same time.

![image](https://github.com/user-attachments/assets/74186716-aa9e-4e2c-9470-e5036547302d)
