### PR TITLE
Partially disabling ssra encounters (see PR)

### DIFF
--- a/ssratemple/script_init.lua
+++ b/ssratemple/script_init.lua
@@ -1,4 +1,4 @@
 eq.load_encounter("PrimeEducator");
 eq.load_encounter("ArchTormentor");
-eq.load_encounter("CurseCycle");
-eq.load_encounter("Emperor");
+--eq.load_encounter("CurseCycle");
+--eq.load_encounter("Emperor");


### PR DESCRIPTION
This change disables the cursed cycle, and prevents the real emperor from spawning.
However, some loot dropping mobs in the Emp event might still spawn unless they are gated (see notes).

# Note
Please also disable these NPC types from spawning in open world. I wasn't sure how to do that. 
If this is done we can probably re-enable these scripts actually.
```
-- CurseCycle
#A_roar (162210)

-- Emp
#Blood_of_Ssraeshza (162189)
#Ssraeshzian_Blood_Golem (162493)
#Emperor_Ssraeshza (162065) "fake emp"
```