### PR TITLE
Update RingOfFire.lua Boss every 10 waves

### DIFF
--- a/acrylia/encounters/RingOfFire.lua
+++ b/acrylia/encounters/RingOfFire.lua
@@ -137,8 +137,8 @@ function SpawnWave()
 
 	local roll = math.random(100);
 	
-	-- big boss every 15 waves starting at wave 30
-	if ( wave > 29 and wave % 15 == 0 ) then
+	-- big boss every 10 waves starting at wave 10
+	if ( wave > 9 and wave % 10 == 0 ) then
 	
 		local boss = 1;	-- warmonger
 		


### PR DESCRIPTION
This change reduces the number of waves players must wait to spawn the 1st boss down from 30 waves to 10 waves.  

This change will also reduce the number of additional waves players must wait to spawn an additional boss from 15 waves down to 10 waves.