### PR TITLE
Improve Bastion of Thunder progression access and loot

### DIFF
--- a/bothunder/encounters/ProgressionLoot.lua
+++ b/bothunder/encounters/ProgressionLoot.lua
@@ -1,0 +1,51 @@
+local GUARANTEED_LOOT = {
+	[209070] = { 17168, 3 }, -- Laef Windfall: Ring of Torden
+	[209071] = { 17168, 3 }, -- Gaukr Sandstorm: Ring of Torden
+	[209072] = { 17168, 3 }, -- Oreen Wavecrasher: Ring of Torden
+	[209082] = { 17168, 3 }, -- Hreidar Lynhillig: Ring of Torden
+	[209016] = { 17169, 1 }, -- Brynju Thunderclap: Unadorned Symbol of Torden
+	[209059] = { 17169, 1 }, -- Auliffe Chaoswind: Unadorned Symbol of Torden
+	[209060] = { 17169, 1 }, -- Eindride Icestorm: Unadorned Symbol of Torden
+	[209061] = { 17169, 1 }, -- Kuanbyr Hailstorm: Unadorned Symbol of Torden
+	[209142] = { 17169, 1 }, -- Ekil Thundercall: Unadorned Symbol of Torden
+	[209146] = { 17169, 1 }, -- Hibdin Cyclone: Unadorned Symbol of Torden
+	[209147] = { 17169, 1 }, -- Jolur Sandstorm: Unadorned Symbol of Torden
+	[209148] = { 17169, 1 }, -- Oljin Stormtide: Unadorned Symbol of Torden
+};
+
+local COMPONENT_LOOT = {
+	[209001] = 9421, [209004] = 9421, [209011] = 9421, -- Sandstorm Gem
+	[209007] = 9422, [209009] = 9422, [209064] = 9422, -- Lightning Gem
+	[209014] = 9423, [209018] = 9423, [209055] = 9423, [209062] = 9423, -- Blizzard Gem
+	[209000] = 9424, [209002] = 9424, [209051] = 9424, [209162] = 9424, -- Tornado Gem
+	[209015] = 9429, [209040] = 9429, [209041] = 9429, -- Sandstorm Sphere
+	[209013] = 9430, [209019] = 9430, [209020] = 9430, -- Lightning Sphere
+	[209043] = 9431, [209044] = 9431, [209133] = 9431, [209134] = 9431, [209161] = 9431, -- Blizzard Sphere
+	[209048] = 9432, [209050] = 9432, [209135] = 9432, -- Tornado Sphere
+};
+
+function ProgressionLootSpawn(e)
+	local npc_type = e.self:GetNPCTypeID();
+	local guaranteed = GUARANTEED_LOOT[npc_type];
+
+	if ( guaranteed ) then
+		for i = 1, guaranteed[2] do
+			e.self:AddItem(guaranteed[1], 1);
+		end
+	end
+
+	local component = COMPONENT_LOOT[npc_type];
+	if ( component and math.random(100) <= 25 ) then
+		e.self:AddItem(component, 1);
+	end
+end
+
+function event_encounter_load(e)
+	for npc_type, _ in pairs(GUARANTEED_LOOT) do
+		eq.register_npc_event("ProgressionLoot", Event.spawn, npc_type, ProgressionLootSpawn);
+	end
+
+	for npc_type, _ in pairs(COMPONENT_LOOT) do
+		eq.register_npc_event("ProgressionLoot", Event.spawn, npc_type, ProgressionLootSpawn);
+	end
+end

--- a/bothunder/player.lua
+++ b/bothunder/player.lua
@@ -1,9 +1,10 @@
 -- this works because all players share these globals
 -- logic is: player holding Symbol of Torden clicks on penis; player's raid or group ID is recorded in table
--- all players in his/her raid may then click up for the next 60 seconds.  Symbol and ring not added to keyring in our era
+-- all players in his/her raid may then click up for the next 5 minutes.  Symbol and ring not added to keyring in our era
 
 local raids = {};
 local gargs = 0;	-- remember how many clicks before gargs wake
+local SYMBOL_AUTHORIZATION_SECONDS = 300;
 
 function FindRaid(e)
 	local myRaid = e.self:GetRaid();
@@ -44,15 +45,15 @@ function AddRaid(e)
 	end
 
 	if ( idx ) then
-		raids[idx].expire = now + 60;
+		raids[idx].expire = now + SYMBOL_AUTHORIZATION_SECONDS;
 	else
 		if ( rid > 0 ) then
-			eq.debug("Raid ID "..rid.." may now enter Agnarr's tower for the next 60 seconds");
-			table.insert(raids, { ["rid"] = rid, ["gid"] = 0, ["expire"] = now+60 });
+			eq.debug("Raid ID "..rid.." may now enter Agnarr's tower for the next 5 minutes");
+			table.insert(raids, { ["rid"] = rid, ["gid"] = 0, ["expire"] = now + SYMBOL_AUTHORIZATION_SECONDS });
 			idx = #raids;
 		elseif ( gid > 0 ) then
-			eq.debug("Group ID "..gid.." may now enter Agnarr's tower for the next 60 seconds");
-			table.insert(raids, { ["rid"] = 0, ["gid"] = gid, ["expire"] = now+60 });
+			eq.debug("Group ID "..gid.." may now enter Agnarr's tower for the next 5 minutes");
+			table.insert(raids, { ["rid"] = 0, ["gid"] = gid, ["expire"] = now + SYMBOL_AUTHORIZATION_SECONDS });
 			idx = #raids;
 		end
 	end

--- a/bothunder/script_init.lua
+++ b/bothunder/script_init.lua
@@ -1,0 +1,1 @@
+eq.load_encounter("ProgressionLoot");


### PR DESCRIPTION
Summary
- Extends the Agnarr tower authorization window from 60 seconds to five minutes.
- Defines the affected Ring, Symbol, gem, and sphere drops in one Lua encounter file.

Why
- Sixty seconds does not give an authorized group or raid enough time to enter the tower.
- The paired Server PR removes these drops from the database, so the Quest scripts must provide their replacements.

Behavior
- Clicking with the Symbol of Torden authorizes that group or raid for five minutes.
- Laef Windfall, Gaukr Sandstorm, Oreen Wavecrasher, and Hreidar Lynhillig each receive three Rings of Torden.
- The eight designated tower bosses each receive one Unadorned Symbol of Torden.
- Designated elemental NPCs receive a 25% chance to carry their matching gem or sphere.
- `script_init.lua` loads the new progression-loot encounter.

Validation
- Lua syntax checks passed.
- The exact NPC and item mappings were reviewed against the removed database loot.
- git diff --check passed.

Deployment dependency
- Deploy with EQMacEmu PR #387 in the same release.
- The Server half removes the old database drops; this Quest half supplies their replacements.