### PR TITLE
Adjust Plane of Justice trial reset handling

### DIFF
--- a/pojustice/The_Tribunal.lua
+++ b/pojustice/The_Tribunal.lua
@@ -95,6 +95,36 @@ function MoveCorpses(trialNum)
 	end
 end
 
+function ReturnTrialPlayers(trialNum, message)
+	local mobList = eq.get_entity_list():GetMobList();
+
+	if ( mobList ) then
+		for mob in mobList.entries do
+			if ( mob.valid
+				and mob:IsClient()
+				and mob:GetY() < TRIAL_BOUNDARIES[trialNum][1]
+				and mob:GetY() > TRIAL_BOUNDARIES[trialNum][2]
+				and mob:GetX() < TRIAL_BOUNDARIES[trialNum][3]
+				and mob:GetX() > TRIAL_BOUNDARIES[trialNum][4]
+			) then
+				local client = mob:CastToClient();
+
+				if ( message ) then
+					client:Message(15, message);
+				else
+					client:MovePC(201, 473, 685, 10, 0);
+
+					if ( client:GetPet().valid and not client:GetPet():Charmed() ) then
+						client:GetPet():GMMove(473, 685, 10, 0);
+					end
+
+					eq.get_entity_list():RemoveFromHateLists(client);
+				end
+			end
+		end
+	end
+end
+
 function MoveGroup(zone, client, dist, x, y, z, h)
 	local group = client:GetGroup();
 	local raid = client:GetRaid();
@@ -157,25 +187,45 @@ function event_signal(e)
 	local trialNum = SPAWNPOINT_IDS[e.self:GetSpawnPointID()];
 	
 	if ( e.signal == trialNum ) then
+		ReturnTrialPlayers(
+			trialNum,
+			TRIAL_TEXT[trialNum].." has failed.  The Tribunal's judgment has been rendered.  You will be returned from the trial shortly."
+		);
+		eq.set_timer("failboot"..trialNum, 10000);
 		eq.set_timer("delay"..trialNum, 60000);
 		trialsUnderway[trialNum] = true;
 		eq.debug(TRIAL_TEXT[trialNum].." failed.  Accessible again in 60 seconds", 1);
 	elseif ( e.signal == (trialNum + 6) ) then
-		eq.set_timer("delay"..trialNum, 1800000);
+		eq.set_timer("warn"..trialNum, 540000);
+		eq.set_timer("boot"..trialNum, 599000);
+		eq.set_timer("delay"..trialNum, 600000);
 		trialsUnderway[trialNum] = true;
-		eq.debug(TRIAL_TEXT[trialNum].." success.  Accessible again in 30 minutes", 1);
+		eq.debug(TRIAL_TEXT[trialNum].." success.  Accessible again in 10 minutes", 1);
 	end
 end
 
 function event_timer(e)
-	if ( #e.timer == 6 ) then
-		eq.stop_timer(e.timer);
-		local num = tonumber(e.timer:sub(6, 6));
-		if ( num ) then
-			MoveCorpses(num);
-			trialsUnderway[num] = nil;
-			eq.debug(TRIAL_TEXT[num].." is now available", 1);
-		end
+	local num = tonumber(e.timer:sub(-1));
+
+	if ( not num ) then
+		return;
+	end
+
+	eq.stop_timer(e.timer);
+
+	if ( e.timer:sub(1, 4) == "warn" ) then
+		ReturnTrialPlayers(num, "The Tribunal will summon you from the trial in one minute.");
+
+	elseif ( e.timer:sub(1, 4) == "boot" ) then
+		ReturnTrialPlayers(num, nil);
+
+	elseif ( e.timer:sub(1, 8) == "failboot" ) then
+		ReturnTrialPlayers(num, nil);
+
+	elseif ( e.timer:sub(1, 5) == "delay" ) then
+		MoveCorpses(num);
+		trialsUnderway[num] = nil;
+		eq.debug(TRIAL_TEXT[num].." is now available", 1);
 	end
 end
 

--- a/pojustice/encounters/BurningTrial.lua
+++ b/pojustice/encounters/BurningTrial.lua
@@ -129,6 +129,22 @@ function BossDeath(e)
 	wave = 0;
 end
 
+function BossDeathComplete(e)
+	local corpseList = eq.get_entity_list():GetCorpseList();
+
+	if ( corpseList ) then
+		for corpse in corpseList.entries do
+			if ( corpse.valid
+				and corpse:IsNPCCorpse()
+				and corpse:GetNPCTypeID() == BOSS_TYPE
+			) then
+				corpse:SetDecayTimer(480000);
+				return;
+			end
+		end
+	end
+end
+
 function TrialFail()
 	eq.signal(TRIBUNAL_TYPE, 6);
 	
@@ -142,6 +158,7 @@ function event_encounter_load(e)
 	eq.register_npc_event("BurningTrial", Event.timer, CONTROLLER_TYPE, ControllerTimer);
 	
 	eq.register_npc_event("BurningTrial", Event.death, BOSS_TYPE, BossDeath);
+	eq.register_npc_event("BurningTrial", Event.death_complete, BOSS_TYPE, BossDeathComplete);
 
 	for _, id in ipairs(MOBS) do
 		eq.register_npc_event("BurningTrial", Event.spawn, id, MobSpawn);

--- a/pojustice/encounters/ExecutionTrial.lua
+++ b/pojustice/encounters/ExecutionTrial.lua
@@ -154,6 +154,22 @@ function PrisonerDeath(e)
 	eq.get_entity_list():MessageClose(e.self, true, 200, 0, "The prisoners cry is cut off as his body crumples to the ground.  You have failed.");
 end
 
+function BossDeathComplete(e)
+	local corpseList = eq.get_entity_list():GetCorpseList();
+
+	if ( corpseList ) then
+		for corpse in corpseList.entries do
+			if ( corpse.valid
+				and corpse:IsNPCCorpse()
+				and corpse:GetNPCTypeID() == BOSS_TYPE
+			) then
+				corpse:SetDecayTimer(480000);
+				return;
+			end
+		end
+	end
+end
+
 function TrialFail()
 	eq.signal(TRIBUNAL_TYPE, 2);
 	eq.depop_all(PRISONER_TYPE);
@@ -191,6 +207,7 @@ function event_encounter_load(e)
 	eq.register_npc_event("ExecutionTrial", Event.waypoint_arrive, EXECUTIONER_TYPE, WaypointArrive);
 	
 	eq.register_npc_event("ExecutionTrial", Event.death, BOSS_TYPE, BossDeath);
+	eq.register_npc_event("ExecutionTrial", Event.death_complete, BOSS_TYPE, BossDeathComplete);
 	
 	eq.register_npc_event("ExecutionTrial", Event.death_complete, PRISONER_TYPE, PrisonerDeath);
 

--- a/pojustice/encounters/HangingTrial.lua
+++ b/pojustice/encounters/HangingTrial.lua
@@ -223,6 +223,22 @@ function BossDeath(e)
 	wave = 0;
 end
 
+function BossDeathComplete(e)
+	local corpseList = eq.get_entity_list():GetCorpseList();
+
+	if ( corpseList ) then
+		for corpse in corpseList.entries do
+			if ( corpse.valid
+				and corpse:IsNPCCorpse()
+				and corpse:GetNPCTypeID() == BOSS_TYPE
+			) then
+				corpse:SetDecayTimer(480000);
+				return;
+			end
+		end
+	end
+end
+
 function TrialFail()
 	eq.signal(TRIBUNAL_TYPE, 5);
 	
@@ -242,6 +258,7 @@ function event_encounter_load(e)
 	eq.register_npc_event("HangingTrial", Event.timer, PRISONER3_TYPE, PrisonerTimer);
 
 	eq.register_npc_event("HangingTrial", Event.death, BOSS_TYPE, BossDeath);
+	eq.register_npc_event("HangingTrial", Event.death_complete, BOSS_TYPE, BossDeathComplete);
 
 	for _, id in ipairs(MOBS) do
 		eq.register_npc_event("HangingTrial", Event.spawn, id, MobSpawn);

--- a/pojustice/encounters/LashingTrial.lua
+++ b/pojustice/encounters/LashingTrial.lua
@@ -113,6 +113,22 @@ function SpawnScourge()
 	end
 end
 
+function BossDeathComplete(e)
+	local corpseList = eq.get_entity_list():GetCorpseList();
+
+	if ( corpseList ) then
+		for corpse in corpseList.entries do
+			if ( corpse.valid
+				and corpse:IsNPCCorpse()
+				and corpse:GetNPCTypeID() == BOSS_TYPE
+			) then
+				corpse:SetDecayTimer(480000);
+				return;
+			end
+		end
+	end
+end
+
 function TrialFail()
 	eq.signal(TRIBUNAL_TYPE, 1);
 	
@@ -193,6 +209,7 @@ function event_encounter_load(e)
 	eq.register_npc_event("LashingTrial", Event.death, OGRE_TYPE, OgreDeath);
 	eq.register_npc_event("LashingTrial", Event.death, SPIRIT2_TYPE, Spirit2Death);
 	eq.register_npc_event("LashingTrial", Event.death, BOSS_TYPE, BossDeath);
+	eq.register_npc_event("LashingTrial", Event.death_complete, BOSS_TYPE, BossDeathComplete);
 
 	for _, id in ipairs(MOBS) do
 		eq.register_npc_event("LashingTrial", Event.spawn, id, MobSpawn);

--- a/pojustice/encounters/StoningTrial.lua
+++ b/pojustice/encounters/StoningTrial.lua
@@ -143,6 +143,22 @@ function BossDeath(e)
 	wave = 0;
 end
 
+function BossDeathComplete(e)
+	local corpseList = eq.get_entity_list():GetCorpseList();
+
+	if ( corpseList ) then
+		for corpse in corpseList.entries do
+			if ( corpse.valid
+				and corpse:IsNPCCorpse()
+				and corpse:GetNPCTypeID() == BOSS_TYPE
+			) then
+				corpse:SetDecayTimer(480000);
+				return;
+			end
+		end
+	end
+end
+
 function TrialFail()
 	eq.signal(TRIBUNAL_TYPE, 3);
 	
@@ -163,6 +179,7 @@ function event_encounter_load(e)
 	
 	eq.register_npc_event("StoningTrial", Event.death, ACCUSED_TYPE, AccusedDeath);
 	eq.register_npc_event("StoningTrial", Event.death, BOSS_TYPE, BossDeath);
+	eq.register_npc_event("StoningTrial", Event.death_complete, BOSS_TYPE, BossDeathComplete);
 
 	for _, id in ipairs(MOBS) do
 		eq.register_npc_event("StoningTrial", Event.spawn, id, MobSpawn);

--- a/pojustice/encounters/TortureTrial.lua
+++ b/pojustice/encounters/TortureTrial.lua
@@ -187,6 +187,22 @@ function BossDeath(e)
 	wave = 0;
 end
 
+function BossDeathComplete(e)
+	local corpseList = eq.get_entity_list():GetCorpseList();
+
+	if ( corpseList ) then
+		for corpse in corpseList.entries do
+			if ( corpse.valid
+				and corpse:IsNPCCorpse()
+				and corpse:GetNPCTypeID() == BOSS_TYPE
+			) then
+				corpse:SetDecayTimer(480000);
+				return;
+			end
+		end
+	end
+end
+
 function TrialFail()
 	eq.signal(TRIBUNAL_TYPE, 4);
 	
@@ -204,6 +220,7 @@ function event_encounter_load(e)
 	
 	eq.register_npc_event("TortureTrial", Event.death, PRISONER_TYPE, TrialFail);
 	eq.register_npc_event("TortureTrial", Event.death, BOSS_TYPE, BossDeath);
+	eq.register_npc_event("TortureTrial", Event.death_complete, BOSS_TYPE, BossDeathComplete);
 	eq.register_npc_event("TortureTrial", Event.death, WRAITH_TYPE, WraithDeath);
 
 	for _, id in ipairs(MOBS) do


### PR DESCRIPTION
What changed
- Successful Justice trials now reopen after 10 minutes instead of 30.
- Players receive a one-minute warning and are returned from the trial before it reopens.
- Failed trials return players after 10 seconds and reopen after 60 seconds.
- Boss corpses remain for eight minutes so players have time to loot.
- Returning players also moves their pets and clears remaining NPC hate.

Why
- Completed and failed trials need to cleanly remove participants before another group enters.
- The previous 30-minute success delay was unnecessarily long, while boss corpses still need enough time for looting.

How we tested
- Confirmed all six trial scripts pass Lua syntax validation.
- Completed a trial as a normal player, killed the boss, hailed the Tribunal, and received the character flag.
- Confirmed the Justice trials still function in the open-world zone.
- Ran git diff --check successfully.