### PR TITLE
Improve Manaetic Behemoth trigger and recovery

### DIFF
--- a/poinnovation/encounters/Behemoth.lua
+++ b/poinnovation/encounters/Behemoth.lua
@@ -1,9 +1,11 @@
 local CONTROLLER_TYPE = 206197; -- Weapon_Event_Master
-local WAVE_TIME = 48000;
-local WAKE_TIME = 450000;
+local WAVE_TIME = 48000; -- 48 seconds between waves
+
 local CLOCKWORK_DEVICE_TYPE = 206001;
 local BEHEMOTH_TYPE = 206046;
 local GIWIN_FLAGGER_TYPE = 206203; -- #Giwin_Mirakon
+local BEHEMOTH_SPAWNID = 345273;
+local FAILURE_RETRY = 600000; -- 10 minutes
 
 local WAVE_SPAWNS = {
 	{	-- 12:00
@@ -68,24 +70,13 @@ local kills = 0;
 
 function ControllerSpawn(e)
 	eq.set_timer("wave", WAVE_TIME);
-	eq.set_timer("wake", WAKE_TIME);
 end
 
-function ControllerTimer(e)
-
-	if ( e.timer == "wave" ) then
-		SpawnWave();
-	elseif ( e.timer == "wake" and not woken ) then
-	
+function WakeBehemoth()
+	if ( not woken and kills >= 10 ) then
 		local behe = eq.get_entity_list():GetMobByNpcTypeID(BEHEMOTH_TYPE);
 		
 		if ( behe and behe.valid ) then
-		
-			if ( kills < 10 ) then
-				eq.debug("Refusing to wake the behemonth; not enough kills");
-				return;
-			end
-
 			behe:SetSpecialAbility(24, 0); -- Will Not Aggro off
 			behe:SetSpecialAbility(35, 0); -- No Harm from Players off
 			behe:SetBodyType(5, false); -- Construct
@@ -103,7 +94,7 @@ function ControllerTimer(e)
 			end
 			behe:CastToNPC():AddAISpell(0, spell, 1, 0, -1, -150);
 			
-			eq.set_timer("depop", 1200000, behe);
+			eq.set_timer("depop", 10800000, behe);
 			eq.set_timer("boundscheck", 2000, behe);
 			woken = true;
 			eq.debug("Behemoth awakened");
@@ -111,15 +102,19 @@ function ControllerTimer(e)
 	end
 end
 
-function ControllerSignal(e)
-	if ( e.signal == 1 ) then
-		eq.set_timer("wake", WAKE_TIME);
+function ControllerTimer(e)
+	if ( e.timer == "wave" ) then
+		SpawnWave();
 	end
 end
 
 function BehemothSpawn(e)
 	woken = false;
 	kills = 0;
+	local controller = eq.get_entity_list():GetMobByNpcTypeID(CONTROLLER_TYPE);
+	if (controller and controller.valid) then
+		eq.set_timer("wave", WAVE_TIME, controller);
+	end
 end
 
 function SpawnWave()
@@ -149,14 +144,28 @@ function BehemothTimer(e)
 		if ( e.self:GetX() > 1215 or e.self:GetX() < 1033 or e.self:GetY() > 120 or e.self:GetY() < -120 ) then
 			e.self:GMMove(e.self:CastToNPC():GetSpawnPointX(), e.self:CastToNPC():GetSpawnPointY(), e.self:CastToNPC():GetSpawnPointZ(), e.self:CastToNPC():GetSpawnPointH());
 			e.self:CastSpell(3230, e.self:GetID()); -- Balance of the Nameless
+			e.self:WipeHateList();
+			e.self:Heal();
 		end
 	elseif ( e.timer == "depop" ) then
-		eq.depop_with_timer();
+		local controller = eq.get_entity_list():GetMobByNpcTypeID(CONTROLLER_TYPE);
+		if (controller and controller.valid) then
+			eq.stop_timer("wave", controller);
+		end
+		eq.depop_all(CLOCKWORK_DEVICE_TYPE);
+		eq.get_entity_list():GetSpawnByID(BEHEMOTH_SPAWNID):SetTimer(FAILURE_RETRY);
+		eq.depop();
 		woken = false;
 	end
 end
 
 function BehemothDeathComplete(e)
+	local controller = eq.get_entity_list():GetMobByNpcTypeID(CONTROLLER_TYPE);
+	if (controller and controller.valid) then
+		eq.stop_timer("wave", controller);
+	end
+	eq.depop_all(CLOCKWORK_DEVICE_TYPE);
+	eq.debug("Behemoth defeated; stopped waves and depopped remaining clockwork devices", 1);
 	eq.spawn2(GIWIN_FLAGGER_TYPE, 0, 0, 1013, 0, 2.1, 193);
 	eq.signal(GIWIN_FLAGGER_TYPE, e.killer:GetID()); -- e.killer for death_complete is somebody with kill rights, not death blow
 	woken = false;
@@ -165,7 +174,6 @@ end
 function BlowUp(e)
 	e.self:CastSpell(2321, e.self:GetID());
 	eq.set_timer("depop", 100);
-	eq.signal(CONTROLLER_TYPE, 1);
 end
 
 function DeviceWaypointArrive(e)
@@ -199,6 +207,10 @@ end
 
 function DeviceDeath(e)
 	kills = kills + 1;
+	if (kills == 10) then
+		eq.debug("Behemoth reached 10 qualifying kills; awakening immediately", 1);
+		WakeBehemoth();
+	end
 	if ( exploders[e.self:GetID()] ) then
 		exploders[e.self:GetID()] = nil;
 	end
@@ -207,11 +219,11 @@ end
 function event_encounter_load(e)
 	eq.register_npc_event("Behemoth", Event.spawn, CONTROLLER_TYPE, ControllerSpawn);
 	eq.register_npc_event("Behemoth", Event.timer, CONTROLLER_TYPE, ControllerTimer);
-	eq.register_npc_event("Behemoth", Event.signal, CONTROLLER_TYPE, ControllerSignal);
 
-	-- ensure spawn event executes
-	if ( eq.get_entity_list():IsMobSpawnedByNpcTypeID(CONTROLLER_TYPE) ) then
-		eq.depop_with_timer(CONTROLLER_TYPE);
+	local controller = eq.get_entity_list():GetMobByNpcTypeID(CONTROLLER_TYPE);
+	if (controller and controller.valid) then
+		eq.set_timer("wave", WAVE_TIME, controller);
+		eq.debug("Behemoth controller found and timers initialized", 1);
 	end
 
 	eq.register_npc_event("Behemoth", Event.spawn, BEHEMOTH_TYPE, BehemothSpawn);


### PR DESCRIPTION
What changed
- Manaetic Behemoth awakens immediately after 10 qualifying clockwork-device kills.
- Removed the old timed wake and signal path.
- Gives Behemoth a three-hour active window that pauses during combat.
- Returning Behemoth to his leash point now clears hate and restores his health.
- A failed event stops new device waves, removes existing devices, and allows another attempt after 10 minutes.
- A successful kill also stops the waves and removes remaining devices before spawning Giwin.

Why
- Behemoth should wake from completing the device objective rather than an unrelated timer.
- Leashing should fully reset the encounter.
- Clockwork devices should not continue spawning after success or while Behemoth is waiting to return.

How we tested
- Confirmed the Lua script passes syntax validation.
- Confirmed the 10-device trigger wakes Behemoth.
- Confirmed leashing returns him home, clears hate, and restores health.
- Reviewed the success and failure cleanup paths and ran git diff --check.
- The final clockwork-stop and 10-minute retry path still warrants an accelerated timer check.

Use with EQMacEmu PR #392, which keeps the event out of open world.