### PR TITLE
Use exact device types for endurance room completion

### DIFF
--- a/poinnovation/encounters/EnduranceRoom.lua
+++ b/poinnovation/encounters/EnduranceRoom.lua
@@ -204,7 +204,14 @@ function MobDeath(e)
 		end
 	end
 	
-	if ( roomNum and room[roomNum].wave == 8 and room[roomNum].kills > (TOTAL_SPAWNS_NUM - 15) and e.self:GetCleanName() == "a manaetic device" ) then
+	local is_final_device =
+	e.self:GetNPCTypeID() == DEVICE1_TYPE or
+	e.self:GetNPCTypeID() == DEVICE2_TYPE or
+	e.self:GetNPCTypeID() == DEVICE3_TYPE or
+	e.self:GetNPCTypeID() == DEVICE4_TYPE;
+
+	if ( roomNum and room[roomNum].wave == 8 and
+		room[roomNum].kills > (TOTAL_SPAWNS_NUM - 15) and is_final_device ) then
 		local z = ROOM1Z + 9.376;
 		if ( roomNum == 2 ) then
 			z = ROOM2Z + 9.376;


### PR DESCRIPTION
What changed
- Changed the final endurance-room completion check to use the four intended manaetic-device NPC types.
- Kept the existing wave-eight and kill-count requirements unchanged.
- Completing the check still spawns Assistant Kelrig and signals the room controller.

Why
- The previous check used only the NPC’s displayed name.
- Exact NPC types prevent another NPC with the same name from incorrectly completing the room.

How we tested
- Confirmed the Lua script passes syntax validation.
- Confirmed all four intended device types are accepted.
- Confirmed the wave, kill-count, Kelrig spawn, and controller-signal behavior remains unchanged.
- Ran git diff --check successfully.