### PR TITLE
Speed up Nitram Anizok’s escort

### DIFF
--- a/poinnovation/Nitram_Anizok.lua
+++ b/poinnovation/Nitram_Anizok.lua
@@ -99,6 +99,7 @@ function event_trade(e)
 	if ( not walking and item_lib.check_turn_in(e.self, e.trade, {item1 = 9295, item2 = 9426, item3 = 9434}) ) then
 		e.self:Say("Excellent!  This is wonderful, please follow me!  I will show you the power of my greatest invention.");
 		walking = true;
+		e.self:CastSpell(278, e.self:GetID()); -- Spirit of Wolf (speed up the scripted walk)
 		e.self:CastToNPC():SetNoQuestPause(true); -- do not pause on say events
 		e.self:AssignWaypoints(22);
 		e.self:SetNPCFactionID(1006);


### PR DESCRIPTION
What changed
- Nitram Anizok casts Spirit of Wolf on himself when the completed three-item turn-in starts his scripted escort.
- His dialogue, waypoint path, faction change, and turn-in requirements are unchanged.

Why
- Nitram’s existing scripted walk is unnecessarily slow.

How we tested
- Confirmed the Lua file passes syntax validation.
- Confirmed the speed spell is applied only after the correct turn-in starts the escort.
- Confirmed the existing escort path and event setup remain unchanged.
- Ran git diff --check successfully.