### PR TITLE
Fix Aerin Dar key progression state

### DIFF
--- a/povalor/Captain_Ryglot_Cupperhide.lua
+++ b/povalor/Captain_Ryglot_Cupperhide.lua
@@ -2,7 +2,7 @@ function event_say(e)
 
 	local questState = tonumber(eq.get_qglobals(e.other).pov_orb_quest or 0);
 	
-	if ( questState == 6 ) then
+	if ( questState >= 5 ) then
 
 		if ( e.message:findi("hail") ) then
 			e.self:Say("I am very [busy] at the moment. Perhaps you should come back at another time "..e.other:GetName());
@@ -35,7 +35,7 @@ function event_trade(e)
 	
 	if ( item_lib.check_turn_in(e.self, e.trade, { item1 = 25796, item2 = 25797, item3 = 25798 }) ) then -- globe pieces
 	
-		if ( questState == 6 ) then
+		if ( questState >= 5 ) then
 			e.self:Emote("looks up at you in surprise. 'I can't believe you brought the missing pieces back to me so quickly. I have a team of men who have been looking for these pieces for weeks now. That's quite a feat. Unfortunately, I will be unable to make use of the Crystalline Globe at this time. A message has been dispatched to my platoon asking us to return to the Halls of Honor. It looks as if we'll be joining up with the rest of our company fairly soon. Keep the globe. If you're able to rally enough people together to take on Aerin`Dar then perhaps you'll be able accomplish an objective that our platoon was unable to do. I must go now. Good luck to you "..e.other:GetName()..".'");
 			-- Confirmed Live Experience
 			e.other:QuestReward(e.self, { itemid = 25596, exp = 1 }); -- A Crystalline Globe

--- a/povalor/Master_Sergeant_Aaramis_Daryln.lua
+++ b/povalor/Master_Sergeant_Aaramis_Daryln.lua
@@ -13,7 +13,7 @@ function event_say(e)
 		elseif ( e.message:findi("aerin") ) then
 			e.self:Say("I don't have time to explain the glass dragon to you. Leave before I get angry.");
 			if ( questState == 3 ) then
-				eq.set_global("pov_orb_quest", "4", 1, "H6");
+				eq.set_global("pov_orb_quest", "4", 1, "F");
 			end
 		end
 	
@@ -34,7 +34,7 @@ function event_say(e)
 		elseif ( e.message:findi("mission") ) then
 			e.self:Say("Not so fast, "..e.other:GetName()..". You'll have to speak to the Captain about that. I'm not at liberty to divulge that information at this time. That information is classified. I can tell you, but then I'd have to kill you.' Aaramis laughs. 'Go to Captain Ryglot and he'll be able to fill you in with all the details.");
 			if ( questState == 5 ) then
-				eq.set_global("pov_orb_quest", "6", 1, "H24");
+				eq.set_global("pov_orb_quest", "6", 1, "F");
 			end
 		end
 	else

--- a/povalor/Paralin_Notion.lua
+++ b/povalor/Paralin_Notion.lua
@@ -55,7 +55,7 @@ function event_say(e)
 		elseif ( e.message:findi("things") ) then
 		
 			e.self:Say("You must find the Master Sergeant and tell him that you are here to aid the cause.");
-			eq.set_global("pov_orb_quest", "3", 1, "H6");
+			eq.set_global("pov_orb_quest", "3", 1, "F");
 		end
 	else
 		if ( e.message:findi("hail") ) then
@@ -76,7 +76,7 @@ function event_trade(e)
 			-- Confirmed Live Experience
 			e.other:QuestReward(e.self, {exp = 1});
 			if ( questState == 4 ) then
-				eq.set_global("pov_orb_quest", "5", 1, "H24");
+				eq.set_global("pov_orb_quest", "5", 1, "F");
 			end
 		else
 			e.self:Emote("looks at you in disgust and wonders why you did that.");

--- a/povalor/Sergeant_Johson_Popoah.lua
+++ b/povalor/Sergeant_Johson_Popoah.lua
@@ -1,22 +1,26 @@
 function event_say(e)
 	
-	if ( e.message:findi("hail") ) then
-	
-		local questState = tonumber(eq.get_qglobals(e.other).pov_orb_quest or 0);
+	local questState = tonumber(eq.get_qglobals(e.other).pov_orb_quest or 0);
 
+	if ( e.message:findi("hail") ) then
 		if ( questState == 0 ) then
 			e.self:Say("State your business or leave our [compound].");
 			if ( questState == 0 ) then
-				eq.set_global("pov_orb_quest", "1", 1, "H6");
+				eq.set_global("pov_orb_quest", "1", 1, "F");
 			end
 		else
 			e.self:Say("Leave now before there is bloodshed.");
 			if ( questState == 1 ) then
-				eq.set_global("pov_orb_quest", "2", 1, "H6");
+				eq.set_global("pov_orb_quest", "2", 1, "F");
 			end
 		end
 		
+
 	elseif ( e.message:findi("compound") ) then
 		e.self:Say("This is the primary command center for Che Virtuson. We fall under the leadership and guidance of Captain Ryglot. I must now ask you to leave.");
+		if ( questState == 1 ) then
+			eq.set_global("pov_orb_quest", "2", 1, "F");
+			e.self:Emote("nods as you take your leave.");
+		end
 	end
 end


### PR DESCRIPTION
What changed

- Makes the Aerin Dar key-chain quest states permanent instead of expiring after several hours.
- Advances Sergeant Johson Popoah's opening quest state when the player asks about the compound.
- Allows Captain Ryglot's dialogue and globe-piece turn-in from the appropriate later quest states.

Why

- Prevents players from losing key-chain progress because a temporary quest global expired.
- Fixes the opening conversation becoming stuck or requiring an unintended extra hail.

How we tested

- Confirmed Sergeant Johson's compound dialogue advances correctly in game.
- Reviewed the modified quest-state transitions and permanent global assignments.
- `git diff --check` passed.