### PR TITLE
Adjust Plane of Storms medallions and leader activation

### DIFF
--- a/postorms/encounters/Gurebk.lua
+++ b/postorms/encounters/Gurebk.lua
@@ -1,4 +1,7 @@
 local GUREBK_TYPE = 210332; -- Gurebk,_Lord_of_Krendic
+local KRENDIC_MEDALLION = 28780;
+local IS_PVP_INSTANCE = eq.get_zone_guild_id() == 1;
+local TRASH_MEDALLION_CHANCE = IS_PVP_INSTANCE and 2 or 20;
 local ADDS_TYPES = { -- these are level 56 versions; not the same as zone wanderers
 	210482, -- a_roving_scorpioco
 	210483, -- a_noxious_scorponnis
@@ -10,7 +13,6 @@ local TRASH_GIANT_TYPES = {
 	210407, -- a_jotna_fannsk (warrior)
 	210022, -- a_jotna_her_megir
 };
-local killed = 0;
 local adds = 0;
 local gurebkActive = false;
 
@@ -19,11 +21,6 @@ function TrashDeathCompleteEvent(e)
 	local elist = eq.get_entity_list();
 	
 	if ( not elist:IsMobSpawnedByNpcTypeID(GUREBK_TYPE) ) then
-		return;
-	end
-	
-	killed = killed + 1;
-	if ( killed < 34 ) then
 		return;
 	end
 	
@@ -50,6 +47,8 @@ end
 function TrashSpawnEvent(e)
 	if ( gurebkActive ) then
 		eq.depop_with_timer();
+	elseif ( math.random(100) <= TRASH_MEDALLION_CHANCE ) then
+		e.self:AddItem(KRENDIC_MEDALLION, 1);
 	end
 end
 
@@ -60,11 +59,31 @@ end
 
 function GurebkSpawnEvent(e)
 	gurebkActive = false;
-	killed = 0;
+	local guaranteed = IS_PVP_INSTANCE and 3 or 5;
+	for i = 1, guaranteed do
+		e.self:AddItem(KRENDIC_MEDALLION, 1);
+	end
+	if ( IS_PVP_INSTANCE ) then
+		if ( math.random(100) <= 50 ) then
+			e.self:AddItem(KRENDIC_MEDALLION, 1);
+			e.self:AddItem(KRENDIC_MEDALLION, 1);
+		end
+	else
+		for i = 1, 3 do
+			if ( math.random(100) <= 50 ) then
+				e.self:AddItem(KRENDIC_MEDALLION, 1);
+			end
+		end
+	end
+	eq.set_timer("check_trash", 5000);
 end
 
 function GurebkTimerEvent(e)
-	if ( e.timer == "adds" ) then
+	if ( e.timer == "check_trash" ) then
+		eq.stop_timer(e.timer);
+		TrashDeathCompleteEvent(e);
+
+	elseif ( e.timer == "adds" ) then
 	
 		if ( adds < 6 ) then
 		
@@ -89,7 +108,6 @@ function GurebkTimerEvent(e)
 		e.self:SetBodyType(11, false);   -- make untargetable
 		e.self:SetSpecialAbility(24, 1); -- Will Not Aggro on
 		e.self:SetSpecialAbility(35, 1); -- No Harm from Players on
-		killed = 0;
 		gurebkActive = false;
 		eq.debug("Gurebk inactive");
 	end

--- a/postorms/encounters/Jeplak.lua
+++ b/postorms/encounters/Jeplak.lua
@@ -1,5 +1,8 @@
 local FAKE_JEPLAK_TYPE = 210403; -- Jeplak,_Lord_of_Srerendi
 local REAL_JEPLAK_TYPE = 210472; -- Jeplak,_Lord_of_Srerendi
+local SRERENDI_MEDALLION = 28765;
+local IS_PVP_INSTANCE = eq.get_zone_guild_id() == 1;
+local TRASH_MEDALLION_CHANCE = IS_PVP_INSTANCE and 2 or 20;
 local ADDS_TYPES = {
 	210478, -- a_mangled_traveler
 	210477, -- a_lost_soul
@@ -22,7 +25,6 @@ local SPAWNPOINT_IDS2 = { -- spawns that must die for real Jeplak to become acti
 	346730
 };
 
-local killed = 0;
 local fakeActive = false;
 local realActive = false;
 
@@ -40,22 +42,6 @@ function CountDead(spawns)
 	end
 	
 	return n, allDead;
-end
-
-function IsCompoundNPC(id)
-	local elist = eq.get_entity_list();
-	
-	for _, i in ipairs(SPAWNPOINT_IDS1) do
-		if ( id == i ) then
-			return 1;
-		end
-	end
-	for _, i in ipairs(SPAWNPOINT_IDS2) do
-		if ( id == i ) then
-			return 2;
-		end
-	end
-	return false;
 end
 
 function ActivateJeplak(typeId)
@@ -79,11 +65,6 @@ end
 
 function TrashDeathCompleteEvent(e)
 
-	if ( IsCompoundNPC(e.self:GetSpawnPointID()) ) then
-		killed = killed + 1;
-		--eq.debug("jeplak guards killed == "..killed, 3);
-	end
-	
 	local elist = eq.get_entity_list();
 	local isFakeUp = elist:IsMobSpawnedByNpcTypeID(FAKE_JEPLAK_TYPE);
 	local isRealUp = elist:IsMobSpawnedByNpcTypeID(REAL_JEPLAK_TYPE);
@@ -92,8 +73,8 @@ function TrashDeathCompleteEvent(e)
 		return;
 	end
 	
-	if ( isFakeUp and not fakeActive and killed >= 23 ) then
-		local n, allDead = CountDead(SPAWNPOINT_IDS1);
+	if ( isFakeUp and not fakeActive ) then
+		local _, allDead = CountDead(SPAWNPOINT_IDS1);
 		
 		if ( allDead ) then
 		
@@ -121,9 +102,9 @@ function TrashDeathCompleteEvent(e)
 			ActivateJeplak(FAKE_JEPLAK_TYPE);
 		end
 		
-	elseif ( isRealUp and not realActive and killed >= 34 ) then
+	elseif ( isRealUp and not realActive ) then
 	
-		local n, allDead = CountDead(SPAWNPOINT_IDS2);
+		local _, allDead = CountDead(SPAWNPOINT_IDS2);
 		if ( allDead ) then		
 			ActivateJeplak(REAL_JEPLAK_TYPE);
 		end	
@@ -149,6 +130,10 @@ function TrashSpawnEvent(e)
 			end
 		end
 	end
+
+	if ( math.random(100) <= TRASH_MEDALLION_CHANCE ) then
+		e.self:AddItem(SRERENDI_MEDALLION, 1);
+	end
 end
 
 function FakeDeathEvent(e)
@@ -157,30 +142,50 @@ function FakeDeathEvent(e)
 	eq.unique_spawn(CASTAWAY_TYPE, 0, 0, 346, -2513, -455.56, 0);
 	fakeActive = false;
 	
-	if ( killed >= 34 ) then
-		local n, allDead = CountDead(SPAWNPOINT_IDS2);
-		if ( allDead ) then
-			ActivateJeplak(REAL_JEPLAK_TYPE);
-		end
+	local _, allDead = CountDead(SPAWNPOINT_IDS2);
+	if ( allDead ) then
+		ActivateJeplak(REAL_JEPLAK_TYPE);
 	end
 end
 function RealDeathEvent(e)
 	realActive = false;
 end
 
+function RealSpawnEvent(e)
+	local guaranteed = IS_PVP_INSTANCE and 3 or 5;
+	for i = 1, guaranteed do
+		e.self:AddItem(SRERENDI_MEDALLION, 1);
+	end
+	if ( IS_PVP_INSTANCE ) then
+		if ( math.random(100) <= 50 ) then
+			e.self:AddItem(SRERENDI_MEDALLION, 1);
+			e.self:AddItem(SRERENDI_MEDALLION, 1);
+		end
+	else
+		for i = 1, 3 do
+			if ( math.random(100) <= 50 ) then
+				e.self:AddItem(SRERENDI_MEDALLION, 1);
+			end
+		end
+	end
+end
+
 function FakeSpawnEvent(e)
-	killed = 0;
 	fakeActive = false;
 	eq.depop_all(CASTAWAY_TYPE);
+	eq.set_timer("check_trash", 5000);
 end
 
 function FakeTimerEvent(e)
-	if ( e.timer == "untarget" ) then
+	if ( e.timer == "check_trash" ) then
+		eq.stop_timer(e.timer);
+		TrashDeathCompleteEvent(e);
+
+	elseif ( e.timer == "untarget" ) then
 		eq.stop_timer(e.timer);
 		e.self:SetBodyType(11, false);   -- make untargetable
 		e.self:SetSpecialAbility(24, 1); -- Will Not Aggro on
 		e.self:SetSpecialAbility(35, 1); -- No Harm from Players on
-		killed = 0;
 		fakeActive = false;
 		eq.debug("Fake Jeplak inactive");
 	end
@@ -198,7 +203,6 @@ function RealTimerEvent(e)
 	elseif ( e.timer == "untarget" ) then
 		eq.stop_timer(e.timer);
 		eq.spawn_from_spawn2(FAKE_SPAWN_ID);
-		killed = 0;
 		realActive = false;
 		eq.debug("Real Jeplak despawn");
 		eq.depop();
@@ -251,6 +255,7 @@ function event_encounter_load(e)
 	eq.register_npc_event("Jeplak", Event.combat, FAKE_JEPLAK_TYPE, FakeCombatEvent);
 
 	eq.register_npc_event("Jeplak", Event.death, REAL_JEPLAK_TYPE, RealDeathEvent);
+	eq.register_npc_event("Jeplak", Event.spawn, REAL_JEPLAK_TYPE, RealSpawnEvent);
 	eq.register_npc_event("Jeplak", Event.timer, REAL_JEPLAK_TYPE, RealTimerEvent);
 	eq.register_npc_event("Jeplak", Event.combat, REAL_JEPLAK_TYPE, RealCombatEvent);
 	

--- a/postorms/encounters/MiniBosses.lua
+++ b/postorms/encounters/MiniBosses.lua
@@ -6,7 +6,23 @@ local MINI_TYPES = {
 	210026, -- Laruken_the_Rigid
 	210029, -- Faruek_the_Bold
 }
+local MINI_MEDALLIONS = {
+	[210026] = 28783, -- Laruken: Kelek`Vor
+	[210027] = 28783, -- Zertuken: Kelek`Vor
+	[210028] = 28765, -- Paruek: Srerendi
+	[210029] = 28765, -- Faruek: Srerendi
+	[210032] = 28780, -- Pendubk: Krendic
+	[210033] = 28780, -- Solnebk: Krendic
+}
 local STORM_TYPE = 210467; -- a_tumultuous_storm
+
+function MiniSpawnEvent(e)
+	local medallion = MINI_MEDALLIONS[e.self:GetNPCTypeID()];
+	local maximum = (eq.get_zone_guild_id() == 1) and 2 or 3;
+	for i = 1, math.random(1, maximum) do
+		e.self:AddItem(medallion, 1);
+	end
+end
 
 function MiniTimerEvent(e)
 	if ( e.timer == "storms" ) then
@@ -40,6 +56,7 @@ end
 function event_encounter_load(e)
 
 	for _, id in ipairs(MINI_TYPES) do
+		eq.register_npc_event("MiniBosses", Event.spawn, id, MiniSpawnEvent);
 		eq.register_npc_event("MiniBosses", Event.timer, id, MiniTimerEvent);
 		eq.register_npc_event("MiniBosses", Event.combat, id, MiniCombatEvent);
 	end

--- a/postorms/encounters/Neffiken.lua
+++ b/postorms/encounters/Neffiken.lua
@@ -1,4 +1,7 @@
 local NEFFIKEN_TYPE = 210251; -- Neffiken,_Lord_of_Kelek`Vor
+local KELEKVOR_MEDALLION = 28783;
+local IS_PVP_INSTANCE = eq.get_zone_guild_id() == 1;
+local TRASH_MEDALLION_CHANCE = IS_PVP_INSTANCE and 2 or 20;
 local TREE_TYPES = {
 	210479, -- a_maligned_ent
 	210480, -- a_manipulated_ent
@@ -12,7 +15,6 @@ local TRASH_GIANT_TYPES = {
 local DOLSHAK_TYPE = 210468;
 local DOLSHAK_SPAWNID = 369224;
 
-local killed = 0;
 local trees = 0;
 local neffikenActive = false;
 
@@ -21,11 +23,6 @@ function TrashDeathCompleteEvent(e)
 	local elist = eq.get_entity_list();
 	
 	if ( not elist:IsMobSpawnedByNpcTypeID(NEFFIKEN_TYPE) ) then
-		return;
-	end
-	
-	killed = killed + 1;
-	if ( killed < 34 ) then
 		return;
 	end
 	
@@ -52,6 +49,8 @@ end
 function TrashSpawnEvent(e)
 	if ( neffikenActive ) then
 		eq.depop_with_timer();
+	elseif ( math.random(100) <= TRASH_MEDALLION_CHANCE ) then
+		e.self:AddItem(KELEKVOR_MEDALLION, 1);
 	end
 end
 
@@ -64,12 +63,32 @@ end
 function NeffikenSpawnEvent(e)
 	neffikenActive = false;
 	eq.depop_with_timer(DOLSHAK_TYPE);
-	killed = 0;
+	local guaranteed = IS_PVP_INSTANCE and 3 or 5;
+	for i = 1, guaranteed do
+		e.self:AddItem(KELEKVOR_MEDALLION, 1);
+	end
+	if ( IS_PVP_INSTANCE ) then
+		if ( math.random(100) <= 50 ) then
+			e.self:AddItem(KELEKVOR_MEDALLION, 1);
+			e.self:AddItem(KELEKVOR_MEDALLION, 1);
+		end
+	else
+		for i = 1, 3 do
+			if ( math.random(100) <= 50 ) then
+				e.self:AddItem(KELEKVOR_MEDALLION, 1);
+			end
+		end
+	end
+	eq.set_timer("check_trash", 5000);
 end
 
 function NeffikenTimerEvent(e)
 
-	if ( e.timer == "trees" ) then
+	if ( e.timer == "check_trash" ) then
+		eq.stop_timer(e.timer);
+		TrashDeathCompleteEvent(e);
+
+	elseif ( e.timer == "trees" ) then
 		if ( trees < 8 ) then
 		
 			local t, dist;
@@ -104,7 +123,6 @@ function NeffikenTimerEvent(e)
 		e.self:SetBodyType(11, false);   -- make untargetable
 		e.self:SetSpecialAbility(24, 1); -- Will Not Aggro on
 		e.self:SetSpecialAbility(35, 1); -- No Harm from Players on
-		killed = 0;
 		neffikenActive = false;
 		eq.debug("Neffiken inactive");
 	end


### PR DESCRIPTION
What changed

- Awards matching medallions through the Plane of Storms encounter scripts.
- Gives normal trash a 20% medallion chance and Guild 1 trash a 2% chance.
- Gives secondary minibosses 1–3 medallions normally and 1–2 in Guild 1.
- Gives each leader 5–8 medallions normally and either 3 or 5 in Guild 1.
- Activates the three leaders based on whether their required giants are actually dead instead of relying on fixed kill counters.
- Checks the required giant state shortly after a leader spawns so an already-cleared camp can activate correctly.

Why

- Prevents kill counters from becoming inaccurate after respawns or encounter resets.
- Makes medallion progression less dependent on long respawn bottlenecks while keeping Guild 1 rewards lower.

How we tested

- Tested the adjusted medallion rewards and leader activation behavior in Plane of Storms.
- Reviewed the normal and Guild 1 reward ranges for trash, minibosses, and leaders.
- `git diff --check` passed.

Deployment note

- Deploy with EQMacEmu PR #394, which removes the old database medallion drops and supplies the matching respawn adjustments.