### PR TITLE
Improve Maareq encounter cleanup and feedback

### DIFF
--- a/potorment/Maareq_the_Prophet.lua
+++ b/potorment/Maareq_the_Prophet.lua
@@ -93,5 +93,6 @@ function event_death_complete(e)
 	local tylis = eq.get_entity_list():GetMobByNpcTypeID(207014); -- Tylis_Newleaf
 	if ( tylis and tylis.valid ) then
 		tylis:SetBodyType(1, false);	-- make targetable
+		eq.zone_emote(0, "Maareq's hold over Tylis fades, and the tormented prisoner begins to stir within his cage.");
 	end
 end

--- a/potorment/a_minion_of_Maareq.lua
+++ b/potorment/a_minion_of_Maareq.lua
@@ -8,6 +8,7 @@ function event_timer(e)
 	local boss = eq.get_entity_list():GetMobByNpcTypeID(207004); -- Maareq_the_Prophet
 	if ( not boss or not boss.valid ) then
 		eq.depop();
+		return;
 	end
 	
 	if ( e.timer == "check" ) then


### PR DESCRIPTION
What changed

- Stops Maareq's minions from continuing their timer processing after they depop because Maareq is missing.
- Adds a zone message when Maareq dies and Tylis becomes targetable.

Why

- Prevents a minion from trying to use an invalid Maareq reference during encounter cleanup.
- Makes it clear to players that Maareq's hold over Tylis has ended.

How we tested

- Verified the missing-boss path depops the minion and returns immediately.
- Verified Maareq's death still removes his minions and makes Tylis targetable before sending the message.
- `git diff --check` passed.