### PR TITLE
Fix Saryrn reset and leash handling

### DIFF
--- a/potorment/Saryrn.lua
+++ b/potorment/Saryrn.lua
@@ -54,7 +54,7 @@ end
 
 function event_combat(e)
 	if ( e.joined ) then
-		eq.stop_timer("checkup");
+		eq.stop_timer("checkhp");
 		eq.set_timer("bounds", 5000);
 	else
 		--eq.get_entity_list():GetSpawnByID(SORROWSONG_SPAWNID):SetTimer(1); -- force spawn Sorrowsong
@@ -71,6 +71,7 @@ function event_timer(e)
 		if ( e.self:GetZ() < 575 ) then
 			e.self:GMMove(e.self:GetSpawnPointX(), e.self:GetSpawnPointY(), e.self:GetSpawnPointZ(), e.self:GetSpawnPointH());
 			e.self:CastSpell(3230, e.self:GetID()); -- Balance of the Nameless
+			e.self:WipeHateList();
 		end
 	
 	elseif ( e.timer == "checkhp" ) then


### PR DESCRIPTION
What changed

- Stops Saryrn's health-reset timer when she is re-engaged.
- Clears her hate list after the bounds check moves her back to her spawn point.

Why

- The combat handler previously stopped a nonexistent `checkup` timer instead of the active `checkhp` timer.
- Moving Saryrn home without clearing her hate list could leave her aggroed after a leash.

How we tested

- Verified the combat handler now starts and stops the same `checkhp` timer.
- Reviewed the leash path to confirm Saryrn is moved home, balanced, and has her hate list cleared.
- `git diff --check` passed.

Dependencies

- This Quest PR does not directly require EQMacEmu PR #376.
