### PR TITLE
Improve Tylis ready response and Sphere guidance

### DIFF
--- a/potorment/Tylis_Newleaf.lua
+++ b/potorment/Tylis_Newleaf.lua
@@ -1,6 +1,10 @@
 local KEY_ITEM_ID = 22954; -- Screaming Sphere
 
 function RaidHasKey(client)
+	if ( client:KeyRingCheck(KEY_ITEM_ID) or client:HasItem(KEY_ITEM_ID) ) then
+		return true;
+	end
+
 	local group = client:GetGroup();
 	local raid = client:GetRaid();
 
@@ -54,7 +58,7 @@ function event_say(e)
 				noflag = true;
 			end
 		
-		elseif ( e.message:findi("we are ready") ) then
+		elseif ( e.message:findi("we are ready") or e.message:findi("i am ready") ) then
 		
 			if ( qglobals.tylis and RaidHasKey(e.other) ) then
 				e.self:CastSpell(1134, e.other:GetID()); -- Insanity of Tylis
@@ -64,7 +68,11 @@ function event_say(e)
 		end
 			
 		if ( noflag ) then
-			e.other:Message(0, "Tylis Newleaf tells you, 'I sense the desire in you to help, but I don't know if you possess the kind of power needed to release me from my anguish.  Please seek out my companion Fahlia and see if she can offer you a way to better yourself before undertaking this task.'");
+			if ( qglobals.tylis ) then
+				e.other:Message(0, "Tylis Newleaf tells you, 'The Screaming Sphere carries an echo of this place.  Bring one near, and perhaps I can channel you into the shadows of my pain.'");
+			else
+				e.other:Message(0, "Tylis Newleaf tells you, 'I sense the desire in you to help, but I don't know if you possess the kind of power needed to release me from my anguish.  Please seek out my companion Fahlia and see if she can offer you a way to better yourself before undertaking this task.'");
+			end
 		end
 	end
 end


### PR DESCRIPTION
What changed

- Checks the requesting player for the Screaming Sphere before checking their group or raid.
- Allows both “we are ready” and “I am ready” to trigger Tylis's teleport.
- Gives Screaming Sphere guidance when a player has the Tylis progression flag but does not have access to the key.
- Preserves the existing Fahlia guidance for players who lack the progression flag.

Why

- Makes the ready response work naturally for solo players as well as groups and raids.
- Distinguishes a missing key from missing quest progression so players receive useful guidance.

How we tested

- Reviewed the solo, group, and raid key-check paths.
- Verified both supported ready phrases use the same flag and key requirements.
- Verified the two failure messages correspond to missing-key and missing-progression cases.
- `git diff --check` passed.

Dependencies

- It complements the larger teleport radius in EQMacEmu PR #399 but does not technically depend on it.