### PR TITLE
Keep Argan safe during Visions of Argan

### DIFF
--- a/potorment/#Argan_Milek.lua
+++ b/potorment/#Argan_Milek.lua
@@ -1,4 +1,5 @@
 function event_spawn(e)
+	e.self:SetNPCFactionID(0); -- keep Argan out of NPC faction combat while available for the player event
 
 	if ( not eq.get_entity_list():IsMobSpawnedByNpcTypeID(207047) ) then -- A_Horrifying_Vision
 		eq.depop_with_timer();


### PR DESCRIPTION
What changed

- Sets Argan Milek's NPC faction to neutral when he spawns.
- Leaves his player dialogue and Visions of Argan trigger unchanged.

Why

- Prevents nearby NPC faction combat from killing or disrupting Argan while he is available for the player event.

How we tested

- Verified the faction change occurs immediately when Argan spawns.
- Verified the existing vision-presence check, dialogue, and teleport spell remain unchanged.
- `git diff --check` passed.

Dependencies

- None.