### PR TITLE
Reduce Halls of Honor trial failure timers

### DIFF
--- a/hohonora/encounters/Crazed.lua
+++ b/hohonora/encounters/Crazed.lua
@@ -318,7 +318,7 @@ function FailEvent()
 		end
 	end
 	
-	eq.update_spawn_timer(ALEKSON_SPAWNID, 10800000);
+	eq.update_spawn_timer(ALEKSON_SPAWNID, 600000);
 	eq.zone_emote(0, "A woman screams in anguish as she's forcibly taken away by a band of crazed norrathians.");
 	eq.debug("Crazed Norathians trial failed");
 end

--- a/hohonora/encounters/RyddaDar.lua
+++ b/hohonora/encounters/RyddaDar.lua
@@ -166,7 +166,7 @@ function RyddaTimer(e)
 		end
 	
 	elseif ( e.timer == "depop" ) then
-		eq.update_spawn_timer(TRYDAN_SPAWNID, 10800000);
+		eq.update_spawn_timer(TRYDAN_SPAWNID, 600000);
 		eq.debug("Rydda`Dar trial failed");
 		EnableSpawns();
 		eq.depop();

--- a/hohonora/encounters/Villagers.lua
+++ b/hohonora/encounters/Villagers.lua
@@ -252,7 +252,7 @@ function FailEvent()
 		end
 	end
 	
-	eq.update_spawn_timer(RHALIQ_SPAWNID, 10800000);
+	eq.update_spawn_timer(RHALIQ_SPAWNID, 600000);
 	eq.debug("Villagers trial failed");
 end
 


### PR DESCRIPTION
## What changed

- Reduces the failed-attempt respawn timer for the Crazed Norrathians trial from three hours to ten minutes.
- Reduces the failed-attempt respawn timer for the Rydda'Dar trial from three hours to ten minutes.
- Reduces the failed-attempt respawn timer for the Villagers trial from three hours to ten minutes.
- Leaves successful completion behavior unchanged.

## Why

- Allows another attempt after a failed trial without requiring a three-hour wait.
- Uses the same ten-minute recovery period for all three Halls of Honor trials.

## How we tested

- Verified all three failure paths now set their trial starter respawn to 600,000 milliseconds.
- Verified that 600,000 milliseconds is exactly ten minutes.
- Verified the successful completion paths were not changed.
- `git diff --check` passed.

## Dependencies

- None.