### PR TITLE
Improve Solusek Ro Tower failure recovery

### DIFF
--- a/solrotower/#Rizlona.lua
+++ b/solrotower/#Rizlona.lua
@@ -1,3 +1,5 @@
+local RIZLONA_SPAWNID = 367546;
+
 function event_death_complete(e)
 	eq.spawn2(212413, 0, 0, -980, 2717, -908, 0);	-- a_flaming_cauldron
 	eq.spawn2(212418, 0, 0, -1087, 2022, -902, 128);	-- a_warder_of_Rizonla
@@ -6,7 +8,7 @@ function event_death_complete(e)
 end
 
 function event_spawn(e)
-	eq.set_timer("depop", 3600000);
+	eq.set_timer("depop", 9000000);
 end
 
 function event_timer(e)
@@ -22,6 +24,7 @@ function event_timer(e)
 		end
 		
 	elseif ( e.timer == "depop" ) then
+		eq.get_entity_list():GetSpawnByID(RIZLONA_SPAWNID):SetTimer(600000);
 		eq.depop();
 	end
 end

--- a/solrotower/The_Protector_of_Dresolik.lua
+++ b/solrotower/The_Protector_of_Dresolik.lua
@@ -1,3 +1,5 @@
+local GUARDIAN_SPAWNIDS = { 367793, 367794, 367795, 367796 };
+
 function event_death_complete(e)
 	eq.spawn2(212414, 0, 0, 166, 1449, -68, 0);	-- a_flaming_cauldron
 	eq.spawn2(212419, 0, 0, 976, 1918, -158, 64);	-- a_warder_of_Dresolik
@@ -6,7 +8,7 @@ function event_death_complete(e)
 end
 
 function event_spawn(e)
-	eq.set_timer("depop", 3600000);
+	eq.set_timer("depop", 9000000);
 end
 
 function event_timer(e)
@@ -21,6 +23,10 @@ function event_timer(e)
 		end
 		
 	elseif ( e.timer == "depop" ) then
+		local elist = eq.get_entity_list();
+		for _, id in ipairs(GUARDIAN_SPAWNIDS) do
+			elist:GetSpawnByID(id):SetTimer(600000);
+		end
 		eq.depop();
 	end
 end


### PR DESCRIPTION
## What changed

- Extends Rizlona's attempt window from one hour to 2.5 hours.
- Extends the Protector of Dresolik's attempt window from one hour to 2.5 hours.
- Keeps each attempt timer paused while its boss is in combat.
- If Rizlona's attempt expires, her encounter trigger becomes available again after ten minutes.
- If the Protector's attempt expires, the four Guardian of Dresolik triggers become available again after ten minutes.
- Leaves each encounter's successful death behavior unchanged.

## Why

- Gives raids a reasonable amount of time to complete either encounter.
- Prevents time spent actively fighting the boss from consuming the failure timer.
- Allows another attempt ten minutes after a failed event instead of leaving the trigger unavailable for its normal long respawn.

## How we tested

- Verified both attempt timers are set to 9,000,000 milliseconds, which is exactly 2.5 hours.
- Verified both timers pause when combat begins and resume when combat ends.
- Verified the failure path sets the relevant trigger spawnpoints to 600,000 milliseconds, which is exactly ten minutes.
- Verified Rizlona resets one trigger and the Protector resets all four Guardian triggers.
- Verified the successful death paths were not changed.
- `git diff --check` passed.
- An accelerated in-game test of both complete failure paths is still recommended.

## Dependencies

- None.