### PR TITLE
Restrict Plane of Air raid encounters to guild raid windows

### DIFF
--- a/poair/script_init.lua
+++ b/poair/script_init.lua
@@ -1,5 +1,10 @@
-eq.load_encounter("Wind");
-eq.load_encounter("Smoke");
-eq.load_encounter("Mist");
-eq.load_encounter("Dust");
-eq.load_encounter("Xegony");
+-- Raid rings and Xegony run in Guild 2+ and during an active Guild 1 quake.
+-- Open world and inactive Guild 1 retain normal trash and individual scripts.
+local guild_id = eq.get_zone_guild_id();
+if ( guild_id > 1 or (guild_id == 1 and eq.guild_one_raid_window_open()) ) then
+	eq.load_encounter("Wind");
+	eq.load_encounter("Smoke");
+	eq.load_encounter("Mist");
+	eq.load_encounter("Dust");
+	eq.load_encounter("Xegony");
+end


### PR DESCRIPTION
## What changed

- Loads the Wind, Smoke, Mist, Dust, and Xegony raid encounter scripts in Guild 2 and higher instances.
- Loads those encounter scripts in Guild 1 only while an earthquake or enabled timed raid window is active.
- Does not load the five raid encounter controllers in the open world.
- Does not load them in Guild 1 while its raid window is closed.
- Leaves normal zone trash and individual NPC scripts available outside the raid encounters.

## Why

- Keeps the scripted Plane of Air rings and Xegony aligned with the same guild-instance rules as the static raid spawnpoints.
- Prevents scripted raid encounters from appearing in open world or bypassing a closed Guild 1 raid window.
- Preserves ordinary Plane of Air activity when the raid encounters are unavailable.

## How we tested

- Verified the script loads all five raid encounters in Guild 2 and higher instances.
- Verified Guild 1 uses `eq.guild_one_raid_window_open()` before loading the encounters.
- Verified the open-world path does not load the five raid encounter controllers.
- Verified the change is limited to `poair/script_init.lua`.
- `git diff --check` passed.

## Dependencies

- Requires EQMacEmu PR #376.
- Requires EQMacEmu PR #402 for `eq.guild_one_raid_window_open()`.
- Deploy with EQMacEmu PR #407 for complete static and scripted Plane of Air raid gating.