### PR TITLE
Improve Plane of Earth raid gating and recovery

### DIFF
--- a/poeartha/script_init.lua
+++ b/poeartha/script_init.lua
@@ -1,5 +1,12 @@
-eq.load_encounter("StoneRing");
-eq.load_encounter("MudRing");
-eq.load_encounter("VineRing");
-eq.load_encounter("DustRing");
+-- Keep ordinary ring mobs in the open world without allowing their raid
+-- encounters to start. Guild 2+ retains all four rings, while Guild 1 only
+-- receives them during an enabled raid window.
+local guild_id = eq.get_zone_guild_id();
+if ( guild_id > 1 or (guild_id == 1 and eq.guild_one_raid_window_open()) ) then
+	eq.load_encounter("StoneRing");
+	eq.load_encounter("MudRing");
+	eq.load_encounter("VineRing");
+	eq.load_encounter("DustRing");
+end
+
 eq.load_encounter("Traps");

--- a/poearthb/#Avatar_of_Earth.lua
+++ b/poearthb/#Avatar_of_Earth.lua
@@ -1,12 +1,20 @@
 local PLANAR_PROJECTION_TYPE = 222041; -- Essence_of_Earth
+local COUNCIL_SPAWN_IDS = { 369377, 369380, 369382, 369384, 369386, 369387, 369376, 369378, 369379, 369381, 369383, 369385 };
+
+function SetCouncilRespawn(seconds)
+	for _, id in ipairs(COUNCIL_SPAWN_IDS) do
+		eq.update_spawn_timer(id, seconds * 1000);
+	end
+end
 
 function event_death_complete(e)
 	eq.spawn2(PLANAR_PROJECTION_TYPE, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 0);
 	eq.signal(PLANAR_PROJECTION_TYPE, e.killer:GetID()); -- e.killer for death_complete is somebody with kill rights, not death blow
+	SetCouncilRespawn(237600); -- restart the Council 2 days, 18 hours after Avatar dies
 end
 
 function event_spawn(e)
-	eq.set_timer("depop", 2100000);
+	eq.set_timer("depop", 9000000); -- 2.5 hours; paused while Avatar is engaged
 end
 
 function event_combat(e)
@@ -20,6 +28,7 @@ end
 function event_timer(e)
 	if ( e.timer == "depop" ) then
 		eq.debug("Avatar of Earth depop");
+		SetCouncilRespawn(420); -- failed Avatar attempt: restore the Council after 7 minutes
 		eq.depop();
 	end
 end

--- a/poearthb/A_Rathe_Councilman.lua
+++ b/poearthb/A_Rathe_Councilman.lua
@@ -200,12 +200,16 @@ function event_death_complete(e)
 
 	local elist = eq.get_entity_list();
 	if ( not elist:IsMobSpawnedByNpcTypeID(MEZABLE_TYPE) and not elist:IsMobSpawnedByNpcTypeID(UNMEZABLE_TYPE) ) then
+		-- Defense in depth: never allow the completed Council event to produce
+		-- its raid boss outside an instance.
+		if ( eq.get_zone_guild_id() == -1 ) then
+			return;
+		end
 	
 		eq.zone_emote(0, "The last of the council falls to the ground all signs of life gone.  Suddenly twelve voices are heard chanting a mystical spell saying, 'Time comes and time passes for the stone is forever.  Now we call upon our collective power to defend our stronghold!'  The chanting then stops and a deep throated primal scream is heard as the power of twelve comes together as one.  The Avatar of Earth has been summoned to defend Ragrax.");
 		eq.unique_spawn(222040, 0, 0, 2050, 410, -210, 0); -- #Avatar_of_Earth
 
-		local variance = math.random(1, 1440);
-		local t = (60 * 60 + variance) * 60; -- (60 hours/2.5 days * 60 minutes + variance) * 60 seconds
+		local t = 237600; -- 2 days, 18 hours
 		for i, id in ipairs(SPAWNIDS) do
 			eq.update_spawn_timer(id, t*1000);
 		end


### PR DESCRIPTION
## What changed

### Earth A rings

- Loads the Stone, Mud, Vine, and Dust ring encounter scripts in Guild 2 and higher instances.
- Loads the four ring encounters in Guild 1 only while an earthquake or enabled timed raid window is active.
- Does not load the raid ring controllers in the open world.
- Leaves ordinary ring-area NPCs and the trap encounter available outside the raid encounters.

### Rathe Council and Avatar of Earth

- Prevents the Rathe Council from summoning Avatar of Earth in the open world.
- When all 12 Council members are defeated in an instance, summons Avatar of Earth and sets the Council to a fixed 66-hour respawn.
- If Avatar of Earth is defeated, restarts the Council's 66-hour respawn from the time of Avatar's death.
- If Avatar is not defeated, allows 2.5 hours to complete the encounter.
- Pauses the 2.5-hour failure timer while Avatar is in combat.
- If that timer expires, despawns Avatar and makes the Council available again after seven minutes.

## Why

- Keeps the scripted Earth A rings and Earth B raid boss aligned with the guild-instance raid rules.
- Preserves ordinary Earth A activity while preventing the raid encounters from starting in open world.
- Gives raids a reasonable amount of time to fight Avatar of Earth without counting active combat against the failure timer.
- Provides a short recovery after a failed Avatar attempt instead of forcing another 66-hour wait.
- Anchors the successful Council lockout to completion of the Avatar encounter.

## How we tested

- Confirmed the Earth ring encounters initialized correctly in Guild 1 during an active raid window.
- Verified Guild 1 checks `eq.guild_one_raid_window_open()` before loading the four ring encounters.
- Verified Guild 2 and higher instances load the ring encounters without that Guild 1 check.
- Verified the open-world path leaves the ring controllers unloaded while retaining the trap script.
- Verified Avatar of Earth cannot be summoned in the open world.
- Verified the Council and successful Avatar paths set all 12 Council spawnpoints to 237,600 seconds, or 66 hours.
- Verified Avatar's failure timer is 9,000,000 milliseconds, or 2.5 hours, and pauses during combat.
- Verified a failed Avatar attempt resets the Council to 420 seconds, or seven minutes.
- `git diff --check` passed.
- The complete 66-hour expiration was not tested in real time.

## Dependencies

- Requires EQMacEmu PR #376.
- Requires EQMacEmu PR #402 for `eq.guild_one_raid_window_open()`.
- Requires EQMacEmu PR #408 for the matching raid markers, lockouts, instance timers, and instrument-loot adjustment.