### PR TITLE
Reduce Coirnav failure recovery

### DIFF
--- a/powater/encounters/Coirnav.lua
+++ b/powater/encounters/Coirnav.lua
@@ -210,10 +210,7 @@ function MonstrousSignal(e)
 		eq.depop_all(NRINDA_TYPE);
 		eq.depop_all(VAMUIL_TYPE);
 		eq.depop_with_timer(COIRNAV_TYPE);
-		
-		if ( phase == 1 ) then
-			eq.update_spawn_timer(COIRNAV_SPAWNID, 10800000);
-		end
+		eq.update_spawn_timer(COIRNAV_SPAWNID, 600000); -- 10-minute failure recovery
 	end
 end
 


### PR DESCRIPTION
## What changed

- Sets Coirnav's encounter trigger to return ten minutes after a failed event.
- Applies the ten-minute recovery regardless of which encounter phase failed.
- Preserves the existing failure cleanup for Coirnav, the Triumvirate, and all event adds.
- Leaves successful Coirnav completion behavior unchanged.

## Why

- The previous recovery timer applied only when the event failed during phase one.
- A failure during a later phase could leave the encounter following its normal long respawn.
- Applying one ten-minute recovery to every failure path makes retries consistent.

## How we tested

- Verified the failure path still removes Coirnav, all three members of the Triumvirate, and all event adds.
- Verified the encounter trigger is set to 600,000 milliseconds, which is exactly ten minutes.
- Verified the reset is no longer limited to phase one.
- Verified the successful death path was not changed.
- `git diff --check` passed.

## Dependencies

- None.