### PR TITLE
Pair Plane of Time guild instances

### DIFF
--- a/potimea/219053.lua
+++ b/potimea/219053.lua
@@ -19,7 +19,7 @@ local RUN_SPEED_BUFFS = { 220,1922,3185, 424,1554,2002, 874,1340, 169, 278,1776,
 
 local activeRaidID, activeInstanceID, numRaiders, activePhase, quarmState = 0, 0, 0, 0, 0;
 local trialRaiders = {};
-local block, playerZoned;
+local block, playerZoned, pendingStartData, startSignalTries;
 
 function Unpacket(s, numberize, returnTable)
 	local t = {};
@@ -36,6 +36,10 @@ function Unpacket(s, numberize, returnTable)
 	end
 end
 
+function SignalTimeB(signal, data)
+	eq.cross_zone_signal_npc_by_npc_type_id(POTIMEB_CONTROLLER_TYPE, eq.get_zone_guild_id(), signal, data or "");
+end
+
 function event_signal(e)
 
 	if ( e.signal == 1 ) then		-- new instance started
@@ -47,10 +51,12 @@ function event_signal(e)
 			activeRaidID = raidID;
 			activeInstanceID = instanceID;
 			numRaiders, activePhase, quarmState = 0, 1, 0;
+			pendingStartData, startSignalTries = nil, 0;
+			eq.stop_timer("start_retry");
 			for i = 1, 9 do
 				trialRaiders[i] = 0;
 			end
-			eq.signal(POTIMEB_CONTROLLER_TYPE, 2);	-- send confirm
+			SignalTimeB(2);	-- send confirm
 			block = false;
 			eq.stop_timer("unblock");
 			--eq.zone_emote(0, "The portal flashes briefly, then glows steadily.");
@@ -65,7 +71,7 @@ function event_signal(e)
 		
 		activePhase = -1;
 		eq.set_timer("cooldown", 120000);
-		eq.signal(POTIMEB_CONTROLLER_TYPE, 2);	-- send confirm
+		SignalTimeB(2);	-- send confirm
 		eq.debug("Plane of Time instance expired.");
 	
 	elseif ( e.signal == 3 ) then			-- player clicked dial; sent from dial
@@ -87,7 +93,10 @@ function event_signal(e)
 
 		if ( activeRaidID == 0 and activeInstanceID == 0 and activePhase == 0 ) then
 			-- TimeB is inactive and not cooling down, relay signal
-			eq.signal(POTIMEB_CONTROLLER_TYPE, 1, 0, e.data..";"..charName);
+			pendingStartData = e.data..";"..charName;
+			startSignalTries = 12;
+			SignalTimeB(1, pendingStartData);
+			eq.set_timer("start_retry", 5000);
 			block = true;	-- block signals until the instance is started
 			eq.set_timer("unblock", 60000); -- in case signals are lost somehow
 			
@@ -150,7 +159,7 @@ function event_signal(e)
 				end				
 			end
 			
-			if ( numRaiders >= 60 or (activePhase == 1 and trialRaiders[dialNum] >= 18) or p2reject ) then
+			if ( numRaiders >= 72 or (activePhase == 1 and trialRaiders[dialNum] >= 18) or p2reject ) then
 				client:Message(0, "The energy has been drained from this portal.  You must wait before you can use it.");
 			else
 				client:Message(0, "The portal glows and the mists of time swirl around you.");
@@ -175,14 +184,14 @@ function event_signal(e)
 					end
 				end
 
-				eq.signal(POTIMEB_CONTROLLER_TYPE, 3, 0, client:CharacterID()..";"..dialNum);
+				SignalTimeB(3, client:CharacterID()..";"..dialNum);
 				
 				local loc = TRIAL_TELEPORTS[dialNum];
 				if ( PHASE_LOCS[activePhase] ) then
 					loc = PHASE_LOCS[activePhase];
 				end
 				playerZoned = true;
-				client:MovePC(TIMEB_ZONEID, loc[1], loc[2], loc[3], loc[4]);
+				client:MovePCGuildID(TIMEB_ZONEID, eq.get_zone_guild_id(), loc[1], loc[2], loc[3], loc[4]);
 			end
 		end
 		
@@ -193,9 +202,11 @@ function event_signal(e)
 		end
 
 		activeRaidID, activeInstanceID, activePhase = Unpacket(e.data, true);
+		pendingStartData, startSignalTries = nil, 0;
+		eq.stop_timer("start_retry");
 		
 		eq.debug("PoTimeB (instance ID "..activeInstanceID.."; raid ID "..activeRaidID..") active phase is now "..activePhase);
-		eq.signal(POTIMEB_CONTROLLER_TYPE, 2);	-- send confirm
+		SignalTimeB(2);	-- send confirm
 		block = false;
 	
 	elseif ( e.signal == 5 ) then		-- periodic player counts
@@ -255,6 +266,14 @@ function event_timer(e)
 		--eq.debug("unblocked", 3);
 	elseif ( e.timer == "cooldown" ) then
 		ResetZone();
+	elseif ( e.timer == "start_retry" ) then
+		if ( pendingStartData and startSignalTries > 0 ) then
+			SignalTimeB(1, pendingStartData);
+			startSignalTries = startSignalTries - 1;
+			return;
+		end
+		pendingStartData = nil;
+		block = false;
 	end
 	eq.stop_timer(e.timer);
 end

--- a/potimea/player.lua
+++ b/potimea/player.lua
@@ -16,6 +16,11 @@ function event_click_door(e)
 			return;
 		end
 
+		if ( eq.get_zone_guild_id() == 1 and not eq.guild_one_raid_window_open() ) then
+			e.self:Message(13, "The flow of time is too stable for this portal to open.");
+			return;
+		end
+
 		local raid = e.self:GetRaid();
 		
 		if ( not e.self:GetGM() and e.self:GetLevel() < 65 ) then

--- a/potimeb/223077.lua
+++ b/potimeb/223077.lua
@@ -1,6 +1,6 @@
 -- Plane of Time B instance controller
 
-local MAX_CLIENTS = 60;
+local MAX_CLIENTS = 72;
 local POTIMEA_CONTROLLER_TYPE = 219053;
 local POTIMEB_CONTROLLER_TYPE = 223077;
 local EVENTS_CONTROLLER_TYPE = 223078;
@@ -548,9 +548,13 @@ function DoAdditionalHoursEmote(hours)
 	eq.zone_emote(0, string.format(EMOTE_STRINGS[4], msg));
 end
 
+function SignalTimeA(signal, data)
+	eq.cross_zone_signal_npc_by_npc_type_id(POTIMEA_CONTROLLER_TYPE, eq.get_zone_guild_id(), signal, data or "");
+end
+
 -- repeat signal until we get a reply but give up after some tries.  make sure important signals get received
 function SendSignalRequestConfirm(signal, data)
-	eq.signal(POTIMEA_CONTROLLER_TYPE, signal, 0, data);
+	SignalTimeA(signal, data);
 	eq.set_timer("confirm", 5000);
 	signalTries = 10;
 	confirmData = data;
@@ -777,7 +781,7 @@ function event_timer(e)
 				data = data..tostring(regionCounts[i])..";";
 			end
 			data = data..tostring(activeClients);
-			eq.signal(POTIMEA_CONTROLLER_TYPE, 5, 0, data);
+			SignalTimeA(5, data);
 			
 			pulses = pulses + 1;
 			if ( pulses == 3 ) then
@@ -809,7 +813,7 @@ function event_timer(e)
 			eq.debug("Critical error: no response from PoTimeA sending signal "..confirmSignal.."!");
 		else
 			eq.debug("PoTimeA failed to send signal confirmation");
-			eq.signal(POTIMEA_CONTROLLER_TYPE, confirmSignal, 0, confirmData);
+			SignalTimeA(confirmSignal, confirmData);
 			return;
 		end
 		
@@ -921,7 +925,7 @@ function PhaseDialog()
 		eq.set_timer("fail", (failTime - now)*1000);
 		eq.stop_timer("fail_warning");
 		eq.stop_timer("fail2");
-		eq.signal(POTIMEA_CONTROLLER_TYPE, 6, 0, "5");
+		SignalTimeA(6, "5");
 		eq.debug("Quarm defeated.  Remaining instance time set to 1 hour.");
 		return;
 	end


### PR DESCRIPTION
## What changed

- Raises the Plane of Time instance capacity from 60 to 72 players.
- Keeps players in their guild's instance when moving from Plane of Time A to Plane of Time B.
- Sends event signals between the matching guild copies of Time A and Time B.
- Retries the initial Time B signal if the destination zone is still starting.
- Prevents Guild 1 from entering Plane of Time outside its active raid window.
- Leaves the existing 18-player limit for each Phase One trial unchanged.

## Why

Plane of Time A and Time B must share progression only within the same guild instance. Without guild-aware movement and signals, one guild could enter or affect another guild's copy of Plane of Time.

The capacity is raised to 72 so a full EverQuest raid can participate.

## How we tested

- Tested two different guilds and confirmed they were routed into separate Plane of Time B instances.
- Confirmed players retained their guild instance when moving from Time A to Time B.
- Confirmed Guild 1 was denied entry outside its active raid window.
- Reviewed the Time A and Time B admission checks and confirmed both limits are set to 72.
- Confirmed the existing Phase One trial limit remains set to 18 players per trial.

## Dependencies

- Requires EQMacEmu#410 for guild-aware player movement and cross-zone NPC signals.
- Requires EQMacEmu#402 for the Guild 1 raid-window check.
- EQMacEmu#402 depends on the raid-respawn foundation in SecretsOTheP/EQMacEmu#376.