### PR TITLE
Set elemental encounter respawn timers

### DIFF
--- a/poearthb/#Avatar_of_Earth.lua
+++ b/poearthb/#Avatar_of_Earth.lua
@@ -10,7 +10,7 @@ end
 function event_death_complete(e)
 	eq.spawn2(PLANAR_PROJECTION_TYPE, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 0);
 	eq.signal(PLANAR_PROJECTION_TYPE, e.killer:GetID()); -- e.killer for death_complete is somebody with kill rights, not death blow
-	SetCouncilRespawn(237600); -- restart the Council 2 days, 18 hours after Avatar dies
+	SetCouncilRespawn(496800); -- restart the Council 5 days, 18 hours after Avatar dies
 end
 
 function event_spawn(e)

--- a/poearthb/A_Rathe_Councilman.lua
+++ b/poearthb/A_Rathe_Councilman.lua
@@ -206,10 +206,10 @@ function event_death_complete(e)
 			return;
 		end
 	
-		eq.zone_emote(0, "The last of the council falls to the ground all signs of life gone.  Suddenly twelve voices are heard chanting a mystical spell saying, 'Time comes and time passes for the stone is forever.  Now we call upon our collective power to defend our stronghold!'  The chanting then stops and a deep throated primal scream is heard as the power of twelve comes together as one.  The Avatar of Earth has been summoned to defend Ragrax.");
+		eq.zone_emote(0, "The last of the council falls to the ground all signs of life gone.  Suddenly twelve voices are heard chanting a mystical spell saying, 'Time comes and time passes for the Stone is forever.  Now we call upon our collective power to defend our Stronghold!'  The chanting then stops and a deep throated primal scream is heard as the Power of Twelve comes together as One.  The Avatar of Earth has been summoned to defend Ragrax.");
 		eq.unique_spawn(222040, 0, 0, 2050, 410, -210, 0); -- #Avatar_of_Earth
 
-		local t = 237600; -- 2 days, 18 hours
+		local t = 496800; -- 5 days, 18 hours
 		for i, id in ipairs(SPAWNIDS) do
 			eq.update_spawn_timer(id, t*1000);
 		end

--- a/pofire/encounters/Fennin.lua
+++ b/pofire/encounters/Fennin.lua
@@ -17,6 +17,9 @@ local PROLLAZ_TYPE = 217428; -- Warlord_Prollaz
 local ELITE_TYPE = 217430; -- elite_guardian_of_ro
 local FENNIN_TYPE = 217440; -- Fennin_Ro_the_Tyrant_of_Fire
 local PROJECTION_TYPE = 217454; -- Essence_of_Fire
+local GUARDIAN_SPAWN_ID = 367088;
+local FAILURE_RETRY_TIME = 64800 * 1000; -- 18 hours
+local SUCCESS_RESPAWN_TIME = 496800 * 1000; -- 5 days, 18 hours
 
 local TRASH_TYPES = {
 	REAVER_TYPE, HEALER_TYPE, MAGUS_TYPE, DARKFIEND_TYPE, CHAOSFIEND_TYPE, RAGEFIEND_TYPE, AZOBIAN_TYPE, 
@@ -272,6 +275,8 @@ function ControllerTimer(e)
 		end
 		eq.depop_all(FENNIN_TYPE);
 		ToggleElites(false);
+
+		eq.update_spawn_timer(GUARDIAN_SPAWN_ID, FAILURE_RETRY_TIME);
 	end
 end
 
@@ -290,9 +295,10 @@ end
 
 function FenninDeathComplete(e)
 	eq.signal(CONTROLLER_TYPE, 2);
+	eq.update_spawn_timer(GUARDIAN_SPAWN_ID, SUCCESS_RESPAWN_TIME);
 	eq.spawn2(PROJECTION_TYPE, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 0);
 	eq.signal(PROJECTION_TYPE, e.killer:GetID()); -- e.killer for death_complete is somebody with kill rights, not death blow
-	eq.zone_emote(0, "Loud cries of hopelessness echo throughout the burning lands. The creatures of Doomfire call out to their master, Fennin Ro the Tyrant of Fire, for his dead body now lies at the feet of the mighty adventurers.");
+	eq.zone_emote(0, "Loud cries of hopelessness echo throughout the Burning Lands. The creatures of Doomfire call out to their Master, Fennin Ro the Tyrant of Fire, for his dead body now lies at the feet of the mighty adventurers.");
 end
 
 function event_encounter_load(e)


### PR DESCRIPTION
## What changed

- Changes the Rathe Council and Avatar of Earth successful completion cycle from 66 hours to five days, 18 hours.
- Gives the Guardian of Doomfire an 18-hour respawn after a failed Fennin event.
- Gives the Guardian of Doomfire a five-day, 18-hour respawn after Fennin is defeated.
- Leaves Avatar of Earth's seven-minute failure recovery unchanged.
- Leaves Fennin's active encounter timer and combat-pausing behavior unchanged.
- Includes minor capitalization corrections in the Rathe Council and Fennin encounter messages.

## Why

The four elemental gods are intended to use five-day, 18-hour reuse timers.

Fennin requires separate success and failure handling because the Guardian of Doomfire starts the encounter. A successful kill should begin the full elemental-boss cooldown, while a failed event should become available again after 18 hours.

Avatar of Earth also requires script handling because the Rathe Council controls when the encounter becomes available.

## How we tested

- Reviewed the Fennin event controller, failure handler, and death handler.
- Confirmed the failure path schedules the Guardian of Doomfire for 18 hours.
- Confirmed Fennin's death schedules the Guardian for five days, 18 hours.
- Confirmed Avatar's successful death and Council completion both use five days, 18 hours.
- Confirmed Avatar's seven-minute failed-attempt recovery remains unchanged.
- `git diff --check` passed.
- Gameplay testing has not yet been completed.

## Dependencies

- Requires the companion EQMacEmu PoP raid reuse timer PR #414. 