### PR TITLE
Set scripted PoP raid encounter respawn timers

### DIFF
--- a/codecay/encounters/Bertox.lua
+++ b/codecay/encounters/Bertox.lua
@@ -17,6 +17,7 @@ local BHALY_TYPE = 200227; -- Bhaly_Adan
 
 local SPECTRE_TYPE = 200016; -- #Spectre_of_Corruption
 local SPECTRE_SPAWNID = 360643;
+local SUCCESS_RESPAWN_TIME = 237600 * 1000; -- 66 hours
 
 local SUMMONER_TYPE = 200260; -- Summoner_of_Bertoxxulous
 local CONTROLLER_TYPE = 200195; -- PusEventController
@@ -182,7 +183,8 @@ end
 
 function BertoxDeathComplete(e)
 	eq.signal(CONTROLLER_TYPE, 2);
-	eq.zone_emote(0, "A nimbus of light floods throughs the crypt in one magnificent wave as an earth shattering howl is heard.  The bringer of plagues, lord of all disease and decay, Bertoxxulous has been defeated. Suddenly an urgent whisper fills your head simply saying, 'The Torch of Lxanvom shall burn bright again.  Freedom is now ours, for that we thank you.'");
+	eq.update_spawn_timer(SPECTRE_SPAWNID, SUCCESS_RESPAWN_TIME);
+	eq.zone_emote(0, "A nimbus of light floods throughs the crypt in one magnificent wave as an earth shattering howl is heard.  The Bringer of Plagues, Lord of All Disease and Decay, Bertoxxulous has been defeated. Suddenly an urgent whisper fills your head simply saying, 'The Torch of Lxanvom shall burn bright again.  Freedom is now ours, for that we thank you.'");
 	eq.spawn2(PROJECTION_TYPE, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 0);
 	eq.signal(PROJECTION_TYPE, e.killer:GetID()); -- e.killer for death_complete is somebody with kill rights, not death blow
 end

--- a/poeartha/encounters/DustRing.lua
+++ b/poeartha/encounters/DustRing.lua
@@ -305,7 +305,7 @@ function DespawnTimer(e)
 end
 
 function ResetSpawn(e)
-	eq.set_timer("depop", 18000000);
+	eq.set_timer("depop", 237600000); -- 66 hours after successful completion
 end
 
 function ResetTimer(e)

--- a/poeartha/encounters/MudRing.lua
+++ b/poeartha/encounters/MudRing.lua
@@ -343,7 +343,7 @@ function DespawnTimer(e)
 end
 
 function ResetSpawn(e)
-	eq.set_timer("depop", 18000000);
+	eq.set_timer("depop", 237600000); -- 66 hours after successful completion
 end
 
 function ResetTimer(e)

--- a/poeartha/encounters/StoneRing.lua
+++ b/poeartha/encounters/StoneRing.lua
@@ -329,7 +329,7 @@ function DespawnTimer(e)
 end
 
 function ResetSpawn(e)
-	eq.set_timer("depop", 18000000);
+	eq.set_timer("depop", 237600000); -- 66 hours after successful completion
 end
 
 function ResetTimer(e)

--- a/poeartha/encounters/VineRing.lua
+++ b/poeartha/encounters/VineRing.lua
@@ -216,7 +216,7 @@ function DespawnTimer(e)
 end
 
 function ResetSpawn(e)
-	eq.set_timer("depop", 18000000);
+	eq.set_timer("depop", 237600000); -- 66 hours after successful completion
 end
 
 function ResetTimer(e)

--- a/potactics/encounters/Rallos.lua
+++ b/potactics/encounters/Rallos.lua
@@ -18,6 +18,7 @@ local CORPSE_TYPES = { 214007, 214008, 214009, 214010, 214011 };
 local UNTARGETABLE_SPAWNID = 361379;
 local BERIK_SPAWNID = 361190;
 local GRUNHORK_SPAWNID = 361200;
+local SUCCESS_RESPAWN_TIME = 237600 * 1000; -- 66 hours
 local WRAITH_CORPSE_SPAWNIDS = { 361133, 361135, 361137, 361138, 361140 };
 local ARENA_SPAWNIDS = { 
 	361141, 361347,		-- two arena corpses; this will make the remaining five spawn wraiths
@@ -279,16 +280,18 @@ function VallonHPEvent(e)
 	end
 end
 
-function RespawnDoorGuards()
+function RespawnDoorGuards(delay)
+	delay = delay or 600000; -- 10-minute failure retry
+
 	phase = 0;
 	killerName, killerGName = "", "";
 	local elist = eq.get_entity_list();
 	local grunhork = elist:GetSpawnByID(GRUNHORK_SPAWNID);
 	local berik = elist:GetSpawnByID(BERIK_SPAWNID);
 	grunhork:Enable();
-	grunhork:SetTimer(1);
+	grunhork:SetTimer(delay);
 	berik:Enable();
-	berik:SetTimer(1);
+	berik:SetTimer(delay);
 	eq.debug("Rallos Zek event reset");
 end
 
@@ -456,7 +459,7 @@ end
 function WarlordDeathEvent(e)
 	eq.spawn2(PLANAR_PROJECTION_TYPE, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 0);
 	eq.signal(PLANAR_PROJECTION_TYPE, e.killer:GetID()); -- e.killer for death_complete is somebody with kill rights, not death blow
-	RespawnDoorGuards();
+	RespawnDoorGuards(SUCCESS_RESPAWN_TIME);
 	eq.signal(CONTROLLER_TYPE, 3);
 	eq.debug(string.format("PoTactics Rallos Zek the Warlord slain by %s's raid <%s>", e.killer:GetName(), e.killer:CastToClient():GetGuildName()));
 end


### PR DESCRIPTION
## What

Aligns scripted Planes of Power raid encounter reuse timers with their corresponding loot lockouts.

- Sets successful Bertoxxulous completion to a 66-hour respawn while retaining a 5-minute failure retry.
- Sets successful Plane of Earth A ring completions to 66-hour respawns.
- Sets successful Rallos Zek the Warlord completion to a 66-hour respawn.
- Sets failed Rallos Zek attempts to a 10-minute retry.

## Why

Several scripted encounters bypass their normal database respawn timing. Their scripts need explicit success and failure timers so encounter availability matches the intended lockout schedule.

## Testing

- Reviewed each success and failure path.
- Confirmed the staged diff contains only the six intended encounter files.
- `git diff --cached --check` passes.

## Dependency

Companion to SecretsOTheP/EQMacEmu#414, which updates the corresponding database loot lockouts and spawn timers.