### PR TITLE
Set Halls of Honor trial reuse timers

### DIFF
--- a/hohonora/encounters/Crazed.lua
+++ b/hohonora/encounters/Crazed.lua
@@ -2,6 +2,7 @@ local FLAG_LIMIT = 72;
 local ALEKSON1_TYPE = 211060; -- Alekson_Garn
 local ALEKSON2_TYPE = 211108; -- #Alekson_Garn
 local CUSTODIAN_TYPE = 211078; -- A_Custodian_of_Marr 
+local SUCCESS_RESPAWN_TIME = 64800 * 1000; -- 18 hours
 
 local MIRANDA_TYPE = 211082; -- Miranda_Climmes
 local YDIRA_TYPE = 211083; -- Ydira_Merok
@@ -208,11 +209,11 @@ function AttackerDeath(e)
 end
 
 function BossDeath(e)
-	bossKills = bossKills + 1;
-	
-	if ( bossKills == 3 ) then
-		EventSuccess();
-	end
+    bossKills = bossKills + 1;
+
+    if ( bossKills == 3 ) then
+        EventSuccess();
+    end
 end
 
 function AttackerSpawn(e)
@@ -267,7 +268,9 @@ function StartEvent(x, y)
 	eq.debug("Crazed Norathians trial started");
 end
 
-function EnableSpawns()
+function EnableSpawns(delay)
+    delay = delay or 600000; -- 10-minute failure retry
+
 	eq.depop_all(MIRANDA_TYPE);
 	eq.depop_all(YDIRA_TYPE);
 	
@@ -275,7 +278,7 @@ function EnableSpawns()
 	local spawn;
 	for _, id in ipairs(ROOM_SPAWNIDS) do
 		spawn = elist:GetSpawnByID(id)
-		eq.update_spawn_timer(id, 600000);
+		eq.update_spawn_timer(id, delay);
 		spawn:Enable();
 	end
 end
@@ -324,7 +327,7 @@ function FailEvent()
 end
 
 function EventSuccess()
-	EnableSpawns();
+    EnableSpawns(SUCCESS_RESPAWN_TIME);
 
 	local mob = eq.spawn2(ALEKSON2_TYPE, 0, 0, -2330, -1724, -110.4, 192);
 	mob:Say("Congratulations my friends. You've passed the trial I laid before you.");

--- a/hohonora/encounters/RyddaDar.lua
+++ b/hohonora/encounters/RyddaDar.lua
@@ -3,6 +3,7 @@ local TRYDAN1_TYPE = 211051; -- Trydan_Faye
 local TRYDAN2_TYPE = 211117; -- #Trydan_Faye
 local RYDDA_TYPE = 211107; -- Rydda`Dar
 local CUSTODIAN_TYPE = 211078; -- A_Custodian_of_Marr
+local SUCCESS_RESPAWN_TIME = 64800 * 1000; -- 18 hours
 
 local TRYDAN_SPAWNID = 360859;
 local ROOM_SPAWNIDS = { 360860, 361050, 361051, 361052 };
@@ -113,18 +114,19 @@ function CustodianTimer(e)
 	end
 end
 
-function EnableSpawns()
+function EnableSpawns(delay)
+    delay = delay or 600000; -- 10-minute failure retry
 	local elist = eq.get_entity_list();
 	local spawn;
 	for _, id in ipairs(ROOM_SPAWNIDS) do
 		spawn = elist:GetSpawnByID(id)
-		eq.update_spawn_timer(id, 600000);
+		eq.update_spawn_timer(id, delay);
 		spawn:Enable();
 	end
 end
 
 function RyddaDeathComplete(e)
-	EnableSpawns();
+	EnableSpawns(SUCCESS_RESPAWN_TIME);
 	
 	local client = e.killer:CastToClient();
 	if ( not client.valid ) then

--- a/hohonora/encounters/Villagers.lua
+++ b/hohonora/encounters/Villagers.lua
@@ -2,6 +2,7 @@ local FLAG_LIMIT = 72;
 local RHALIQ1_TYPE = 211050; -- Rhaliq_Trell
 local RHALIQ2_TYPE = 211106; -- #Rhaliq_Trell
 local CUSTODIAN_TYPE = 211078; -- A_Custodian_of_Marr 
+local SUCCESS_RESPAWN_TIME = 64800 * 1000; -- 18 hours
 
 local VILLAGERS = {
 	{ 211093, 638, 1400 }, -- a_barbarian_villager
@@ -220,7 +221,8 @@ function StartEvent()
 	eq.debug("Villagers trial started");
 end
 
-function EnableSpawns()
+function EnableSpawns(delay)
+    delay = delay or 600000; -- 10-minute failure retry
 	for _, t in ipairs(VILLAGERS) do
 		eq.depop_all(t[1]);
 	end
@@ -229,7 +231,7 @@ function EnableSpawns()
 	local spawn;
 	for _, id in ipairs(ROOM_SPAWNIDS) do
 		spawn = elist:GetSpawnByID(id)
-		eq.update_spawn_timer(id, 600000);
+		eq.update_spawn_timer(id, delay);
 		spawn:Enable();
 	end
 end
@@ -257,8 +259,7 @@ function FailEvent()
 end
 
 function EventSuccess()
-	EnableSpawns();
-
+    EnableSpawns(SUCCESS_RESPAWN_TIME);
 	eq.spawn2(RHALIQ2_TYPE, 0, 0, 456, 1374, -110.4, 65);
 	eq.debug("Villagers trial success");
 end


### PR DESCRIPTION
## What

Aligns the scripted Halls of Honor trial reuse timers with their 18-hour loot lockouts.

- Sets successful Crazed Norrathians completion to an 18-hour respawn.
- Sets successful Rydda`Dar completion to an 18-hour respawn.
- Sets successful Villagers completion to an 18-hour respawn.
- Retains the existing 10-minute retry after failed attempts.

## Why

These trials control their room spawn timers through Lua. Successful completions need a longer delay matching their loot lockouts, while failures should remain quickly retryable.

## Testing

- Reviewed the success and failure paths for all three trials.
- Confirmed the branch contains only the three intended encounter files.
- `git diff --cached --check` passes.

## Dependency

Companion to SecretsOTheP/EQMacEmu#414, which defines the corresponding 18-hour loot lockouts.