### PR TITLE
Gate Plane of Air Chamberlain event

### DIFF
--- a/poair/POACastellanController.lua
+++ b/poair/POACastellanController.lua
@@ -17,6 +17,10 @@ local LOCS = {
 local signals = {};
 local kills = 0;
 local spawns = { ALRANDERISAN_TYPE, BELECOHEN_TYPE, FERABALEN_TYPE };
+local function RaidContentEnabled()
+	local guild_id = eq.get_zone_guild_id();
+	return guild_id > 1 or (guild_id == 1 and eq.guild_one_raid_window_open());
+end
 
 function RepopIsland()
 	local elist = eq.get_entity_list();
@@ -49,10 +53,16 @@ function RepopIsland()
 end
 
 function event_spawn(e)
-	eq.set_timer("castellan_repop", 1080000);
+	if ( RaidContentEnabled() ) then
+		eq.set_timer("castellan_repop", 1080000);
+	end
 end
 
 function event_timer(e)
+	if ( not RaidContentEnabled() ) then
+		eq.stop_timer(e.timer);
+		return;
+	end
 
 	if ( e.timer == "castellan_repop" ) then
 		RepopIsland();
@@ -60,6 +70,9 @@ function event_timer(e)
 end
 
 function event_signal(e)
+	if ( not RaidContentEnabled() ) then
+		return;
+	end
 
 	if ( e.signal == 1 ) then
 	


### PR DESCRIPTION
## What

Restricts the Plane of Air Castellan, constable, and Chamberlain event controller to raid-enabled instances.

- Allows the controller to operate in Guild 2+ instances.
- Allows it during an active Guild 1 earthquake window.
- Keeps the controller inert in open world and inactive Guild 1 zones.
- Stops an existing controller timer if raid eligibility ends.

## Why

The Plane of Air ring encounters are already gated through `script_init.lua`, but the Castellan controller is loaded independently. Without equivalent checks, open-world Castellan kills could progress the constable and Chamberlain chain.

## Testing

- Reviewed controller spawn, timer, and signal paths.
- Confirmed the branch contains only `poair/POACastellanController.lua`.
- `git diff --cached --check` passes.

## Dependency

None.