### PR TITLE
Raise Tarkil Adan and EarthA flag limits to 72

### DIFF
--- a/codecay/Tarkil_Adan.lua
+++ b/codecay/Tarkil_Adan.lua
@@ -1,4 +1,4 @@
-local MAX_KEYS = 36;
+local MAX_KEYS = 72;
 
 local keys;
 local rid, gid, cid;


### PR DESCRIPTION
- Increase Tarkil Adan's key/flag award limit from 36 to 72.
- Increase the Plane of Earth A Planar Projection award limit from 54 to 72.
- Align both encounters with the standard 72-player raid flag limit.