### PR TITLE
Restore guild Plane of Time timelines across restarts

### DIFF
--- a/potimea/219053.lua
+++ b/potimea/219053.lua
@@ -100,16 +100,20 @@ function event_signal(e)
 			block = true;	-- block signals until the instance is started
 			eq.set_timer("unblock", 60000); -- in case signals are lost somehow
 			
-		elseif ( activeRaidID ~= raidID ) then
-			-- player is in the wrong raid
-			-- note: this text is not what Sony used.  I don't have a log of what they used so made this up
-			client:Message(0, "The portal glows momentarily before fading.  You see a brief vision of unfamiliar warriors in a great battle against the gods.");
-		
-		
 		elseif ( instanceID > 0 and activeInstanceID ~= instanceID ) then
 			-- player is saved to an instance that is not the same as the active instance
 			
 			local qglobals = eq.get_qglobals(POTIMEB_CONTROLLER_TYPE, 223);
+			local instanceGuildID = tonumber(qglobals["time_guild_"..instanceID]) or 0;
+			local currentGuildID = eq.get_zone_guild_id();
+
+			if ( instanceGuildID == currentGuildID ) then
+			-- Converge an obsolete same-guild pointer on the loaded guild timeline.
+			e.data = charID..";"..dialNum..";"..raidID..";"..activeInstanceID;
+			event_signal(e);
+			return;
+			end
+
 			local instanceTimers = qglobals["time_timers_"..instanceID];
 			local instanceExpired = true;
 			if ( instanceTimers ) then
@@ -131,14 +135,23 @@ function event_signal(e)
 
 			if ( not instanceExpired ) then
 				-- player is saved to an instance with timers not expired.  deny entry
-				-- note: this text is not what Sony used.  I don't have a log of what they used so made this up
-				client:Message(0, "The portal glows momentarily before fading.  You sense that you are not attuned with whoever first activated it.");
+				client:Message(13, "The portal recoils from your touch. Your fate is already bound to another thread of time.");
 			else
 				-- send player into active instance even though IDs don't match
 				e.data = charID..";"..dialNum..";"..raidID..";"..activeInstanceID;
 				event_signal(e);
 				return;
 			end
+
+		elseif ( activeRaidID ~= raidID ) then
+			-- Raid IDs are temporary. The guild instance owns the timeline.
+				eq.debug("Rebinding active Time instance "..activeInstanceID.." from raid "..activeRaidID.." to raid "..raidID);
+				activeRaidID = raidID;
+				SignalTimeB(9, "3;"..raidID);
+				e.data = charID..";"..dialNum..";"..raidID..";"..activeInstanceID;
+				event_signal(e);
+		return;
+
 
 		elseif ( (instanceID == activeInstanceID or instanceID == 0) and raidID == activeRaidID ) then
 			
@@ -254,6 +267,34 @@ function event_signal(e)
 			eq.debug("Quarm state is now "..quarmState);
 		end
 		
+	elseif ( e.signal == 8 ) then			-- saved instance belongs to another guild zone
+
+		local charID = tonumber(e.data);
+		if ( charID ) then
+			local client = eq.get_entity_list():GetClientByCharID(charID);
+			if ( client and client.valid ) then
+				client:Message(13, "The portal recoils from your touch. Your fate is bound to another guild's thread of time.");
+			end
+		end
+		pendingStartData, startSignalTries = nil, 0;
+		eq.stop_timer("start_retry");
+		SignalTimeB(2);
+		block = false;
+
+	elseif ( e.signal == 9 ) then			-- saved timeline retired; a fresh one was created
+
+		local charID = tonumber(e.data);
+		if ( charID ) then
+			local client = eq.get_entity_list():GetClientByCharID(charID);
+			if ( client and client.valid ) then
+				client:Message(13, "The last sands of your former timeline have fallen. A new path through the Plane of Time now lies before you.");
+			end
+		end
+		pendingStartData, startSignalTries = nil, 0;
+		eq.stop_timer("start_retry");
+		SignalTimeB(2);
+		block = false;
+
 	elseif ( e.signal == 7 ) then			-- PoTimeB zone reset
 		ResetZone();
 		eq.debug("PoTimeB script reset");

--- a/potimea/player.lua
+++ b/potimea/player.lua
@@ -22,13 +22,14 @@ function event_click_door(e)
 		end
 
 		local raid = e.self:GetRaid();
+			e.self:Message(15, "DEBUG raid valid: "..tostring(raid.valid)..", members: "..tostring(raid.valid and raid:RaidCount() or 0));
 		
 		if ( not e.self:GetGM() and e.self:GetLevel() < 65 ) then
 			e.self:Message(13, "You lack the will to pass through this portal safely.");
 			return;
 		end
 		if ( not e.self:GetGM() and (not raid.valid or raid:RaidCount() < 7) ) then
-			e.self:Message(0, "You don't have sufficient power to affect things in the Plane of Time. Gather your forces to increase your strength.");
+			e.self:Message(13, "You don't have sufficient power to affect things in the Plane of Time. Gather your forces to increase your strength.");
 			return;
 		end
 
@@ -37,6 +38,13 @@ function event_click_door(e)
 		if ( qglobals.time_instance ) then
 			instanceID = tonumber(qglobals.time_instance) or 0;
 		end
+		local savedGuildID = tonumber(qglobals.time_instance_guild) or 0;
+		local currentGuildID = eq.get_zone_guild_id();
+		if ( instanceID > 0 and savedGuildID > 0 and savedGuildID ~= currentGuildID ) then
+			e.self:Message(13, "The portal recoils from your touch. Your fate is bound to another guild's thread of time.");
+			return;
+		end
+
 		
 		door_id = door_id - 7;
 		

--- a/potimeb/223077.lua
+++ b/potimeb/223077.lua
@@ -5,6 +5,8 @@ local POTIMEA_CONTROLLER_TYPE = 219053;
 local POTIMEB_CONTROLLER_TYPE = 223077;
 local EVENTS_CONTROLLER_TYPE = 223078;
 local QUARM_TYPE = 223008;
+local TIMELINE_LIFETIME = 691200; -- 8 days
+local TIMELINE_GRACE = 108000; -- 30 hours after the latest boss lockout
 
 local EMOTE_STRINGS = {
 	[1] = "An hourglass appears in the distance, the few remaining sands trickling down.  As the last grain falls, multicolored lights erupt from it, surrounding you in a brilliant flash.",
@@ -81,6 +83,7 @@ local zoneRaidID = 0;
 local zoneInstanceID = 0
 local zoneInstanceData = "";
 local zoneTimers = {};
+local zoneHardExpire = 0;
 local zoneBossTable = {};
 local failTime = 0;
 local failWarningMsg;
@@ -152,7 +155,7 @@ end
 
 function KickPlayer(client)
 	if ( client:Connected() ) then
-		client:MovePC(219, math.random(-57, -17), math.random(-130, -90), 10, 0);	-- Plane of Time A evac loc with some randomness
+		client:MovePCGuildID(219, eq.get_zone_guild_id(), math.random(-57, -17), math.random(-130, -90), 10, 0);	-- Plane of Time A evac loc with some randomness
 	end
 end
 
@@ -162,12 +165,7 @@ function SetBossKilled(phase, bossNum)
 	end
 	zoneBossTable[phase][bossNum] = 1;
 	
-	local t = 561600; -- 6.5 days
-	if ( phase == 1 ) then
-		t = 43200; -- 12 hours
-	elseif ( phase == 2 or phase == 3 ) then
-		t = 302400; -- 3.5 days
-	end
+	local t = 583200; -- 6 days, 18 hours
 	
 	local timerNum = phase;
 	if ( phase == 4 ) then
@@ -180,6 +178,9 @@ function SetBossKilled(phase, bossNum)
 	if ( phase > 3 or zoneTimers[timerNum] == 0 ) then  -- phase 1-3 start the timer from the frist boss kill
 		zoneTimers[timerNum] = os.time() + t;
 	end
+	-- Preserve the full boss lockout plus the timeline's recovery window. Ordinary
+	-- saves must never extend this deadline.
+	zoneHardExpire = math.max(zoneHardExpire, zoneTimers[timerNum] + TIMELINE_GRACE);
 	
 	SetInstanceGlobals();
 	return true;
@@ -268,6 +269,7 @@ function SetupNewInstance(controller)
 	end
 	
 	validPlayers = {};
+	zoneHardExpire = os.time() + TIMELINE_LIFETIME;
 	
 	-- look for an open instance slot.  this will break if there are 999 instance qglobals in use
 	local qglobals = eq.get_qglobals(controller);
@@ -280,6 +282,33 @@ function SetupNewInstance(controller)
 		end	
 	end
 	return 0;
+end
+
+function FindGuildInstance(controller, guildID)
+	local qglobals = eq.get_qglobals(controller);
+	local now = os.time();
+	local instanceID = 0;
+
+	for name, value in pairs(qglobals) do
+		local candidateID = tonumber(name:match("^time_guild_(%d+)$"));
+
+		if ( candidateID and tonumber(value) == guildID ) then
+			local hardExpire = tonumber(qglobals["time_expires_"..candidateID]) or 0;
+			local hasState =
+				qglobals["time_kills_"..candidateID] and
+				qglobals["time_timers_"..candidateID];
+
+			if (
+				hasState and
+				(hardExpire == 0 or now < hardExpire) and
+				(instanceID == 0 or candidateID < instanceID)
+			) then
+				instanceID = candidateID;
+			end
+		end
+	end
+
+	return instanceID;
 end
 
 function SetInstanceGlobals()
@@ -302,12 +331,18 @@ function SetInstanceGlobals()
 		end
 	end
 	
-	eq.set_global("time_kills_"..zoneInstanceID, killsStr, 2, "D7");
-	eq.set_global("time_timers_"..zoneInstanceID, timersStr, 2, "D7");
+	eq.set_global("time_kills_"..zoneInstanceID, killsStr, 2, "D8");
+	eq.set_global("time_timers_"..zoneInstanceID, timersStr, 2, "D8");
+	eq.set_global("time_guild_"..zoneInstanceID, tostring(eq.get_zone_guild_id()), 2, "D8");
+	eq.set_global("time_expires_"..zoneInstanceID, tostring(zoneHardExpire), 2, "D8");
 end
 
 function SavePlayerInstance(client)
-	eq.target_global("time_instance", tostring(zoneInstanceID), "D7", 0, client:CharacterID(), 0);
+	-- Keep the character's pointer longer than the timeline itself. The absolute
+	-- timeline deadline decides whether it can be restored, so an early-phase
+	-- participant cannot lose the pointer before a later boss lockout expires.
+	eq.target_global("time_instance", tostring(zoneInstanceID), "D30", 0, client:CharacterID(), 0);
+	eq.target_global("time_instance_guild", tostring(eq.get_zone_guild_id()), "D30", 0, client:CharacterID(), 0);
 
 	-- set zoned-in-from-dial flag to false.  doing this at same time we save player
 	local charID = client:CharacterID();
@@ -573,27 +608,54 @@ function event_signal(e)
 		end
 		eq.debug("Instance start requested; charID "..charID.." ("..(charName or "?")..") clicked dial number "..dialNum.." in raid ID "..raidID.." with instance ID "..instanceID);
 		
-		if ( zonePhase == 0 ) then
-		
-			if ( instanceID == 0 ) then
-				eq.debug("zone inactive and player has no instance; creating new instance and notifying PoTimeA");
-				instanceID = SetupNewInstance(e.self);				
+if ( zonePhase == 0 ) then
+	local currentGuildID = eq.get_zone_guild_id();
+	local guildInstanceID = FindGuildInstance(e.self, currentGuildID);
+
+	if ( guildInstanceID > 0 and guildInstanceID ~= instanceID ) then
+		eq.debug(
+			"Using guild "..currentGuildID..
+			"'s active Time instance "..guildInstanceID..
+			" instead of character instance "..instanceID
+		);
+		instanceID = guildInstanceID;
+	end
+
+	if ( instanceID == 0 ) then
+
+eq.debug("zone inactive and player has no instance; creating new instance and notifying PoTimeA");
+				instanceID = SetupNewInstance(e.self);
 			else
 				eq.debug("zone inactive and player has previous instance; using previous instance");
 				local qglobals = eq.get_qglobals(e.self);
-				local killData = qglobals["time_kills_"..instanceID];
-				local timerData = qglobals["time_timers_"..instanceID];
-				if ( not killData or not timerData ) then
-					instanceID = SetupNewInstance(e.self);					
+				local instanceGuildID = tonumber(qglobals["time_guild_"..instanceID]) or 0;
+				if ( instanceGuildID > 0 and instanceGuildID ~= currentGuildID ) then
+					eq.debug("Rejected Time instance "..instanceID.." owned by guild zone "..instanceGuildID.." from guild zone "..currentGuildID);
+					SendSignalRequestConfirm(8, tostring(charID));
+					return;
+				end
+				local hardExpire = tonumber(qglobals["time_expires_"..instanceID]) or 0;
+				if ( hardExpire > 0 and os.time() >= hardExpire ) then
+					eq.debug("Time instance "..instanceID.." reached its retirement deadline; creating a fresh timeline");
+					instanceID = SetupNewInstance(e.self);
+					SendSignalRequestConfirm(9, tostring(charID));
 				else
-					eq.debug("Instance kill data: "..killData);
-					eq.debug("Instance timer data: "..timerData);
-					eq.debug("current os.time() is "..os.time());
-					if ( not SetInstanceVars(killData, timerData) ) then
-						eq.debug("Error: Time instance qglobals are corrupted!  Instance ID: "..instanceID);
-						return;
-					end					
-					
+					local killData = qglobals["time_kills_"..instanceID];
+					local timerData = qglobals["time_timers_"..instanceID];
+					if ( not killData or not timerData ) then
+						instanceID = SetupNewInstance(e.self);
+					else
+						-- Existing timelines created before this safeguard receive one full
+						-- migration window. Thereafter only boss kills can extend it.
+						zoneHardExpire = hardExpire > 0 and hardExpire or (os.time() + TIMELINE_LIFETIME);
+						eq.debug("Instance kill data: "..killData);
+						eq.debug("Instance timer data: "..timerData);
+						eq.debug("current os.time() is "..os.time());
+						if ( not SetInstanceVars(killData, timerData) ) then
+							eq.debug("Error: Time instance qglobals are corrupted!  Instance ID: "..instanceID);
+							return;
+						end
+					end
 				end
 			end
 			zoneInstanceID = instanceID;
@@ -601,16 +663,42 @@ function event_signal(e)
 				eq.debug("Critical Error: All instance qglobals are in use.");
 				return;
 			end
-			zonePhase = 1;
-			zoneRaidID = raidID;
-			CheckPhaseStatus(1);
-			SendSignalRequestConfirm(1, charID..";"..dialNum..";"..raidID..";"..instanceID); -- Tell PoTimeA that we started an instance
-			SetInstanceGlobals();
-			eq.set_timer("phase1", 45000);
-			eq.set_timer("check_trial_start", 2000);
-			for i = 1, #trialStates do
-				trialStates[i] = 0;
-			end
+zoneRaidID = raidID;
+
+local nextPhase = 0;
+for phase = 1, 6 do
+    if ( CheckPhaseStatus(phase) ) then
+        nextPhase = phase;
+        break;
+    end
+end
+
+SendSignalRequestConfirm(1, charID..";"..dialNum..";"..raidID..";"..instanceID);
+SetInstanceGlobals();
+
+for i = 1, #trialStates do
+    trialStates[i] = 0;
+end
+
+if ( nextPhase == 1 ) then
+    zonePhase = 1;
+    eq.set_timer("phase1", 45000);
+    eq.set_timer("check_trial_start", 2000);
+elseif ( nextPhase > 1 ) then
+    SetupPhaseOne();
+    zonePhase = nextPhase - 1;
+    PhaseDialog();
+else
+    zonePhase = 6;
+    PhaseDialog();
+end
+
+
+
+
+
+
+
 		
 		elseif ( zonePhase > 0 ) then
 			eq.debug("Error: Zone already active and PoTimeA requesting new instance.  This shouldn't happen. (zone crash?)  Sending zone state update");


### PR DESCRIPTION
Guild Plane of Time Timelines Across Restarts

#418 and #131: “Merge together: Plane of Time timeline behavior and #timelockout status support.”

## Summary

This change makes the scripted Plane of Time timeline belong to the guild instance instead of permanently belonging to the raid ID that originally opened it.

Raid IDs are temporary. A raid that clears part of Plane of Time on one day will normally be disbanded and recreated before its next raid night, often under a different raid leader. Previously, the recreated raid received a different raid ID and could not reliably continue the guild's saved Plane of Time timeline. Depending on which character activated the portal and which Time zones were still running, players could be rejected as belonging to another raid or timeline, or TimeB could start or restore the wrong state.

The updated flow persists guild ownership with the timeline, resolves the guild's active timeline when TimeB starts, safely rebinds a newly formed raid to that timeline, and reconstructs the first available phase after a TimeB or full server restart.

## Player-facing behavior

- A guild can clear part of Plane of Time, disband, and reform its raid on a later day.
- The reformed raid may have a different raid leader and therefore a different raid ID.
- A new raid leader who does not yet have a personal `time_instance` pointer can activate the guild's existing timeline.
- Existing guild members with obsolete same-guild pointers converge on the guild's currently loaded timeline.
- Characters cannot use a saved pointer owned by another guild instance.
- Separate guilds receive and resume separate timelines.
- After TimeB or the server restarts, the script restores saved kills and timers, identifies the first phase with an available encounter, runs the appropriate preceding phase RP, and starts the correct encounter controller.
- Players removed from TimeB return to the matching guild-specific TimeA instance.

## Detailed implementation

### `potimea/player.lua`

- Keeps the  minimum raid size at seven members.
- Changes the insufficient-raid message to the red message channel for clearer feedback.
- Reads the character's saved `time_instance_guild` pointer alongside `time_instance`.
- Compares the saved guild pointer with the current TimeA guild instance.
- Rejects a character whose saved active timeline belongs to a different guild, preventing cross-guild timeline entry.
- Retains the temporary raid-valid/member-count diagnostic message for observation during rollout.

### `potimea/219053.lua`

- Evaluates saved-instance mismatches before temporary raid-ID mismatches.
- Resolves the owner of a saved timeline through the persisted `time_guild_<instance>` value.
- Converges obsolete same-guild character pointers onto the guild timeline currently loaded in TimeB.
- Continues to reject a character bound to a different active timeline with unexpired timers.
- Treats raid IDs as replaceable session state rather than permanent timeline ownership.
- When the guild reforms its raid, updates TimeA's active raid ID and signals TimeB to update its running raid ID.
- Reprocesses the portal request after rebinding so the player can continue through the normal capacity and dial checks.
- Adds explicit responses for:
  - a saved timeline owned by another guild;
  - a retired timeline that has been replaced with a fresh one.
- Clears the pending start/retry state after either response so the TimeA controller does not remain blocked.

### `potimeb/223077.lua`

#### Guild timeline ownership

- Adds `time_guild_<instance>` controller globals to persist the guild that owns each timeline.
- Adds `FindGuildInstance()` to scan active controller globals for a valid timeline owned by the current guild.
- Requires matching kill and timer state before a candidate timeline can be restored.
- Ignores candidates whose hard retirement deadline has elapsed.
- Uses the established guild timeline in preference to an absent or obsolete character pointer.
- Rejects restoration when the requested timeline is explicitly owned by another guild.

#### Raid reformation

- Accepts an operation from TimeA that replaces the active raid ID for a running timeline.
- Preserves guild ownership, instance identity, kills, and timers while changing only the temporary raid ID.
- Allows a new raid leader and newly formed raid to continue the same guild timeline.

#### Timeline lifetime and lockouts

- Standardizes boss lockouts at 583,200 seconds (6 days, 18 hours).
- Introduces an eight-day timeline lifetime (`TIMELINE_LIFETIME = 691200`).
- Tracks an absolute `time_expires_<instance>` retirement deadline.
- Extends the hard deadline only from boss-lockout activity, using a 30-hour recovery window beyond the latest boss deadline.
- Prevents ordinary state saves from continually extending the timeline.
- Stores controller kill, timer, guild, and expiration globals for eight days.
- Stores per-character `time_instance` and `time_instance_guild` pointers for 30 days so an early participant's pointer cannot disappear before the authoritative timeline state is evaluated.
- Gives legacy timelines without `time_expires_<instance>` one migration lifetime, after which the absolute deadline controls retirement.

#### Phase restoration

- Restores saved boss and timer state before selecting the live phase.
- Checks Phases 1 through 6 and identifies the first phase with an available encounter.
- Starts Phase 1 normally when Phase 1 still has available encounters.
- When a later phase is the first available phase:
  - initializes the active-zone failure timers;
  - sets the live controller to the preceding completed phase;
  - calls the existing `PhaseDialog()` sequence;
  - allows the existing dialog timer to call `PhaseStart()`;
  - signals the existing phase encounter controller (`201`, `301`, `401`, `501`, or `601`).
- This preserves the existing RP, door activation, encounter startup, and phase-specific behavior instead of directly forcing a phase number.
- Handles a fully completed timeline through the existing Phase 6 completion path.

#### Guild-aware return path

- Changes TimeB eviction/return movement from plain `MovePC()` to `MovePCGuildID()`.
- Returns players to TimeA under the current guild instance instead of losing guild-instance context during the zone transition.

## Persistence model

The authoritative controller state consists of:

- `time_kills_<instance>` — serialized boss kill state for Phases 1–6;
- `time_timers_<instance>` — serialized encounter respawn deadlines;
- `time_guild_<instance>` — owning guild instance ID;
- `time_expires_<instance>` — absolute timeline retirement deadline.

Each participating character receives:

- `time_instance` — the character's last known timeline ID;
- `time_instance_guild` — the guild that owned that timeline.

The guild-owned controller state is authoritative. Character pointers are used to reconnect participants, but an unbound member can still locate the guild timeline and an obsolete same-guild pointer can converge on the active guild timeline.

## Validation performed

- Parsed all three modified Lua files successfully with the Zone container's Lua runtime.
- Ran `git diff --check` successfully on all three files.
- Restored the production seven-member raid requirement after reduced-size local testing.
- Verified a raid could be disbanded and reformed under a different leader and raid ID.
- Verified a new, previously unbound raid leader could locate and enter the guild's existing timeline.
- Verified saved kill and timer data remained visible through `#timelockout` after Zone and full Compose restarts.
- Verified completed Phase 1 state transitioned through the existing RP into Phase 2 after restoration.
- Verified later completed phases selected the correct next available phase and continued the existing phase scripts.
- Verified multi-guild isolation concurrently:
  - Guild 2 restored timeline 1.
  - Guild 3 created and used timeline 2.
  - Neither guild inherited the other guild's timeline state.
- Verified manually copied quest files were rebuilt into the Zone image before the full-restart persistence test.


- The temporary `DEBUG raid valid` player message remains enabled intentionally for initial observation. 


## Files changed

- `potimea/player.lua`
- `potimea/219053.lua`
- `potimeb/223077.lua`